### PR TITLE
Add a modal onClose callback to PiecesSelectionDialog

### DIFF
--- a/components/calculationInput/piecesSelection/PiecesSelectionDialog.tsx
+++ b/components/calculationInput/piecesSelection/PiecesSelectionDialog.tsx
@@ -115,7 +115,7 @@ const PiecesSelectionDialog = ({
   };
 
   return (<Dialog open={isOpened} fullScreen={isFullScreen}
-    keepMounted>
+    keepMounted onClose={handleDialogCancel}>
     <DialogTitle>
       <Box display={'flex'}>
         <Box>{t('addPieceDialog.selectAPiece')}</Box>


### PR DESCRIPTION
Dismiss the equipment selection dialog by clicking outside the dialog or pressing escape, which makes the action easier than using the cancel button on devices with larger screens.