### PR TITLE
Add feature to simulate equipment upgrades

### DIFF
--- a/components/calculationInput/equipments/EquipmentsInput.tsx
+++ b/components/calculationInput/equipments/EquipmentsInput.tsx
@@ -1,21 +1,24 @@
 import styles from './EquipmentsInput.module.scss';
 import BuiLinedText from 'components/bui/text/BuiLinedText';
 import BuiButton from 'components/bui/BuiButton';
-import React, {useState} from 'react';
+import React, {useCallback, useMemo, useState} from 'react';
 import EquipmentsSelectionDialog from 'components/calculationInput/equipments/EquipmentsSelectionDialog';
 import {Equipment} from 'model/Equipment';
 import {EquipmentsById} from 'components/calculationInput/PiecesCalculationCommonTypes';
 import {observer} from 'mobx-react-lite';
 import {IWizStore} from 'stores/WizStore';
 import {EquipmentInfoToEdit, IRequirementByEquipment} from 'stores/EquipmentsRequirementStore';
-import {Card, CardActionArea, Tooltip} from '@mui/material';
-import EquipmentCard from 'components/bui/card/EquipmentCard';
-import BuiBanner from 'components/bui/BuiBanner';
+import {Tooltip} from '@mui/material';
 import PiecesInventory, {PieceState} from 'components/calculationInput/equipments/inventory/PiecesInventory';
 import IconButton from '@mui/material/IconButton';
 import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined';
 import variables from 'scss/variables.module.scss';
 import {useTranslation} from 'next-i18next';
+import {
+  checkRequirementsSatisfied, calculateRequiredPieces,
+} from './inventory/piecesStateCalculator';
+import {LabeledEquipmentCard} from './LabeledEquipmentCard';
+import {KeyboardDoubleArrowUp} from '@mui/icons-material';
 
 export interface TierCategoryKey{
   tier: number;
@@ -78,19 +81,28 @@ const EquipmentsInput = (
     handleCloseEquipmentRequirementDialog();
   };
 
-  const handleOpenDialogForEditing = (requirementByEquipment: IRequirementByEquipment, index: number) => {
-    setEquipInfoToEdit(
-        {
-          ...requirementByEquipment,
-          indexInStoreArray: index,
-        }
-    );
+  const handleOpenDialogForEditing = useCallback((index: unknown) => {
+    if (typeof index !== 'number') return;
+    const requirementByEquipment = store.equipmentsRequirementStore.requirementByEquipments[index];
+    setEquipInfoToEdit({
+      ...requirementByEquipment,
+      indexInStoreArray: index,
+    });
     setIsAddEquipDialogOpened(true);
-  };
+  }, [store.equipmentsRequirementStore.requirementByEquipments]);
+
+  const upgradableBadge = useMemo(() => {
+    return <>
+      <Tooltip title='Upgradable'><KeyboardDoubleArrowUp /></Tooltip>
+      {/* <Tooltip title='Starred'><StarBorder /></Tooltip> */}
+    </>;
+  }, []);
+
   return <div>
     <EquipmentsSelectionDialog
       key={equipInfoToEdit?.targetEquipmentId ?? '1'}
       isOpened={isAddEquipDialogOpened} equipmentsByTier={equipmentsByTier}
+      piecesState={piecesState}
       handleAddEquipmentRequirement={handleAddEquipmentRequirement}
       handleDeleteEquipmentRequirement={handleDeleteEquipmentRequirement}
       handleUpdateEquipmentRequirement={handleUpdateEquipmentRequirement}
@@ -100,27 +112,21 @@ const EquipmentsInput = (
     <BuiLinedText>{t('addEquipments')}</BuiLinedText>
     <div className={styles.selectionWrapper}>
       {store.equipmentsRequirementStore.requirementByEquipments.map((requirementByEquip, index) => {
-        const currentEquip = equipmentsById.get(requirementByEquip.currentEquipmentId);
-        const targetEquip = equipmentsById.get(requirementByEquip.targetEquipmentId);
+        const isUpgradable = checkRequirementsSatisfied(
+            piecesState,
+            calculateRequiredPieces(
+                equipmentsById,
+                equipmentsByTierAndCategory,
+                requirementByEquip
+            )
+        );
 
-        if (!currentEquip || !targetEquip) return null;
-        const tierUpgradeText = `T${currentEquip.tier}→T${targetEquip.tier}`;
-        let nicknameAndCount = '';
-        if (requirementByEquip.nickname?.length) {
-          nicknameAndCount += `[${requirementByEquip.nickname}]`;
-        }
-        nicknameAndCount += requirementByEquip.count.toString();
-
-        return <Card key={index} elevation={1}
-          onClick={() => handleOpenDialogForEditing(requirementByEquip, index)}>
-          <CardActionArea>
-            <div className={styles.selectedPiecePaper}>
-              <EquipmentCard imageName={targetEquip.icon} />
-              <BuiBanner label={tierUpgradeText} width={'120%'} />
-              <BuiBanner label={nicknameAndCount} width={'120%'}/>
-            </div>
-          </CardActionArea>
-        </Card>;
+        return <LabeledEquipmentCard key={index} index={index}
+          showNickname showTier showTierChange
+          onClick={handleOpenDialogForEditing}
+          equipById={equipmentsById}
+          requirement={requirementByEquip}
+          badge={isUpgradable ? upgradableBadge : undefined} />;
       })}
       <BuiButton color={'baButtonSecondary'} onClick={handleClickOpen} className={styles.addButton}>
         <div>{t('addButton')}</div>

--- a/components/calculationInput/equipments/EquipmentsInput.tsx
+++ b/components/calculationInput/equipments/EquipmentsInput.tsx
@@ -81,8 +81,7 @@ const EquipmentsInput = (
     handleCloseEquipmentRequirementDialog();
   };
 
-  const handleOpenDialogForEditing = useCallback((index: unknown) => {
-    if (typeof index !== 'number') return;
+  const handleOpenDialogForEditing = useCallback((_: unknown, index: number) => {
     const requirementByEquipment = store.equipmentsRequirementStore.requirementByEquipments[index];
     setEquipInfoToEdit({
       ...requirementByEquipment,
@@ -92,11 +91,8 @@ const EquipmentsInput = (
   }, [store.equipmentsRequirementStore.requirementByEquipments]);
 
   const upgradableBadge = useMemo(() => {
-    return <>
-      <Tooltip title='Upgradable'><KeyboardDoubleArrowUp /></Tooltip>
-      {/* <Tooltip title='Starred'><StarBorder /></Tooltip> */}
-    </>;
-  }, []);
+    return <Tooltip title={t('canUpgradeBadge')}><KeyboardDoubleArrowUp /></Tooltip>;
+  }, [t]);
 
   return <div>
     <EquipmentsSelectionDialog

--- a/components/calculationInput/equipments/EquipmentsInput.tsx
+++ b/components/calculationInput/equipments/EquipmentsInput.tsx
@@ -118,7 +118,7 @@ const EquipmentsInput = (
         );
 
         return <LabeledEquipmentCard key={index} index={index}
-          showNickname showTier showTierChange
+          showNickname showTierChange
           onClick={handleOpenDialogForEditing}
           equipById={equipmentsById}
           requirement={requirementByEquip}

--- a/components/calculationInput/equipments/EquipmentsSelectionDialog.module.scss
+++ b/components/calculationInput/equipments/EquipmentsSelectionDialog.module.scss
@@ -1,3 +1,19 @@
 .filler{
   flex: 1 0 0;
 }
+
+.equip {
+  display: flex;
+
+  justify-items: center;
+  align-content: center;
+  align-items: center;
+
+  margin-top: 1em;
+
+  user-select: none;
+
+  > * {
+    margin-inline: 0.5rem;
+  }
+}

--- a/components/calculationInput/equipments/EquipmentsSelectionDialog.tsx
+++ b/components/calculationInput/equipments/EquipmentsSelectionDialog.tsx
@@ -38,9 +38,8 @@ import NickNameInput from 'components/calculationInput/equipments/EquipmentDialo
 import {observer} from 'mobx-react-lite';
 import {useStore} from 'stores/WizStore';
 import {calculateRequirementAmount} from 'components/calculationInput/equipments/inventory/piecesStateCalculator';
-import { boolean } from 'mobx-state-tree/dist/internal';
 import UpgradeConfirmationDialog from './UpgradeConfirmationDialog';
-import { PieceState } from './inventory/PiecesInventory';
+import {PieceState} from './inventory/PiecesInventory';
 
 
 export interface IEquipmentFormInputs {
@@ -60,7 +59,6 @@ type EquipmentsSelectionDialogPros = {
   handleAddEquipmentRequirement: (requirementByEquipment: IRequirementByEquipment) => void,
   handleUpdateEquipmentRequirement: (equipmentInfoToEdit: EquipmentInfoToEdit) => void,
   handleDeleteEquipmentRequirement: (equipmentInfoToEdit: EquipmentInfoToEdit) => void,
-  handleUpgradeEquipmentRequirement: (equipmentInfoToEdit: EquipmentInfoToEdit) => void,
   handleCancel: () => void,
   // An entity denotes a pre-selected equipment.
   // Setting this means dialog will be used for editing existing selection.
@@ -73,7 +71,6 @@ const EquipmentsSelectionDialog = (
       handleAddEquipmentRequirement,
       handleUpdateEquipmentRequirement,
       handleDeleteEquipmentRequirement,
-      handleUpgradeEquipmentRequirement,
       handleCancel,
     } : EquipmentsSelectionDialogPros
 ) => {
@@ -195,7 +192,7 @@ const EquipmentsSelectionDialog = (
     });
 
     return enough;
-  }, [isInputValid, baseEquipId, targetEquipId, watch('neededEquipmentsCount')])
+  }, [isInputValid, baseEquipId, targetEquipId, watch('neededEquipmentsCount')]);
 
   const maxTierPerCategory = useMemo(() => {
     const maxTierPerCategoryBuilder: {[key : string]: number} = {};
@@ -279,13 +276,13 @@ const EquipmentsSelectionDialog = (
 
   const handleUpgrade = (equip: EquipmentInfoToEdit, requirements: PieceState[]) => {
     setUpgradeDialogOpened(false);
-    
+
     if (!baseEquipId || !targetEquipId || !equipmentInfoToEdit) return;
     const formValues = getValues();
 
     store.equipmentsRequirementStore.updateInventory(
       requirements.reduce((acc, piece) => {
-        return Object.assign(acc, { [piece.pieceId]: piece.inStockCount - piece.needCount })
+        return Object.assign(acc, { [piece.pieceId]: piece.inStockCount - piece.needCount });
       }, {})
     );
 
@@ -428,7 +425,7 @@ const EquipmentsSelectionDialog = (
       </Button>
     </DialogActions>
 
-    {equipmentInfoToEdit && <UpgradeConfirmationDialog 
+    {equipmentInfoToEdit && <UpgradeConfirmationDialog
       isOpened={isUpgradeDialogOpened}
       equipmentsById={equipmentsById}
       equipmentsByTierAndCategory={equipmentsByTierAndCategory}

--- a/components/calculationInput/equipments/LabeledEquipmentCard.module.scss
+++ b/components/calculationInput/equipments/LabeledEquipmentCard.module.scss
@@ -1,0 +1,17 @@
+@use 'components/calculationInput/common/common-calculation-input-layout';
+
+.card {
+  position: relative;
+}
+
+.container {
+  @include common-calculation-input-layout.items-list;
+}
+
+.badges {
+  position: absolute;
+  top: 3px;
+  right: 3px;
+  display: flex;
+  flex-flow: column nowrap;
+}

--- a/components/calculationInput/equipments/LabeledEquipmentCard.tsx
+++ b/components/calculationInput/equipments/LabeledEquipmentCard.tsx
@@ -1,0 +1,149 @@
+import styles from './LabeledEquipmentCard.module.scss';
+import {Card, CardActionArea} from '@mui/material';
+import BuiBanner from 'components/bui/BuiBanner';
+import EquipmentCard from 'components/bui/card/EquipmentCard';
+import {Equipment} from 'model/Equipment';
+import {ReactNode, memo} from 'react';
+import {EquipmentsById} from '../PiecesCalculationCommonTypes';
+import {PieceState} from './inventory/PiecesInventory';
+import {IRequirementByEquipment} from 'stores/EquipmentsRequirementStore';
+
+// #region
+type EquipIdSource = {
+  equip: Equipment,
+} | {
+  equipId: string,
+} | {
+  requirement: IRequirementByEquipment,
+} | {
+  pieceState: PieceState,
+};
+type EquipmentOrId = {
+  equip: Equipment,
+} | (EquipIdSource & {
+  equipById: EquipmentsById,
+});
+type PieceStateOrId = {
+  pieceState: PieceState,
+} | (EquipIdSource & {
+  piecesState: Map<string, PieceState>,
+});
+
+type ImageName = {imageName: string} | EquipmentOrId;
+type BottomLeftText = ({showTier: true} & EquipmentOrId) | {
+  bottomLeftText?: string,
+  showTier?: false
+};
+type BottomRightText = ({showStockCount: true} & PieceStateOrId) | {
+  bottomRightText?: string,
+  showStockCount?: false
+};
+type NicknameText = {
+  showNickname: true,
+  requirement: IRequirementByEquipment,
+} | {
+  showNickname?: false,
+};
+type TierChangeText = {
+  showTierChange: true,
+  requirement: IRequirementByEquipment,
+  equipById: EquipmentsById,
+} | {
+  showTierChange?: false,
+};
+type NeedCountText = ({showNeedCount: true} & PieceStateOrId) | {
+  showNeedCount?: false,
+};
+
+type Props = ImageName & BottomLeftText & BottomRightText &
+  TierChangeText & NicknameText & NeedCountText & {
+    isSelected?: boolean,
+    index?: unknown,
+    onClick?: (index: unknown) => void,
+    badge?: ReactNode,
+  };
+
+const resolveEquipmentId = (props: EquipIdSource) => {
+  return 'equipId' in props ? props.equipId :
+    'equip' in props ? props.equip.id :
+    'requirement' in props ? props.requirement.targetEquipmentId :
+    props.pieceState.pieceId;
+};
+const resolveEquipment = (props: EquipmentOrId) => {
+  return 'equip' in props ?
+    props.equip :
+    props.equipById.get(resolveEquipmentId(props));
+};
+const resolvePieceState = (props: PieceStateOrId) => {
+  return 'pieceState' in props ?
+    props.pieceState :
+    props.piecesState.get(resolveEquipmentId(props));
+};
+const buildTierChange = (equipById: EquipmentsById, requirement: IRequirementByEquipment) => {
+  const baseTier = equipById.get(requirement.currentEquipmentId)?.tier;
+  const targetTier = equipById.get(requirement.targetEquipmentId)?.tier;
+  return `T${baseTier ?? '?'}→${targetTier ?? '?'}`;
+};
+// const buildNickname = ({nickname, count}: IRequirementByEquipment) => {
+//   return !nickname ? `${count}` :
+//     count == 1 ? `${nickname}` :
+//     `[${nickname}]${count}`;
+// };
+const buildNickname = ({nickname, count}: IRequirementByEquipment) => {
+  return !nickname ? `${count}` : `[${nickname}]${count}`;
+};
+// #endregion
+
+/**
+ * An example of the god component. It seems to slow down VSCode's type checking.
+ * Use with `showTier`, `showNickname`, `showTierChange`, `showNeedCount`
+ * and `showStockCount` switches as needed.
+ *
+ * - `showNickname` and `showTierChange` are for equipment requirements.
+ * - `showNeedCount` and `showStockCount` are for pieces in inventory.
+ *
+ * This is the list of optional arguments
+ * - `equipId: string`
+ * - `equip: Equipment`
+ * - `pieceState: PieceState`
+ * - `requirement: IRequirementByEquipment`
+ * - `piecesState: Map<string, PieceState>`
+ * - `equipById: EquipmentsById`
+ *
+ * One of `equipId`, `equip`, `pieceState` or `requirement` are required.
+ * `piecesState` and `equipById` may be required.
+ * You have to specify `callbackArgs` to make the callback can identify items.
+ */
+export const LabeledEquipmentCard = memo(function LabeledEquipmentCard(props: Props) {
+  const imageName = 'imageName' in props ?
+    props.imageName :
+    resolveEquipment(props)?.icon;
+  const bottomLeftText = props.showTier ?
+    `T${resolveEquipment(props)?.tier ?? '?'}` :
+    props.bottomLeftText;
+  const bottomRightText = props.showStockCount ?
+    `x${resolvePieceState(props)?.inStockCount ?? 0}` :
+    props.bottomRightText;
+  const tierChangeText = props.showTierChange &&
+    buildTierChange(props.equipById, props.requirement);
+  const nicknameText = props.showNickname &&
+    buildNickname(props.requirement);
+  const needCountText = props.showNeedCount &&
+    `${resolvePieceState(props)?.needCount ?? 0}`;
+  const onClick = props.onClick && (() => props.onClick?.(props.index));
+
+  return <Card elevation={1} className={styles.card} onClick={onClick}>
+    <CardActionArea disabled={!onClick}>
+      <div className={styles.container}>
+        {imageName && <EquipmentCard imageName={imageName}
+          bottomLeftText={bottomLeftText}
+          bottomRightText={bottomRightText}
+          isSelected={props.isSelected}/>}
+        {tierChangeText && <BuiBanner label={tierChangeText} width={'120%'} />}
+        {nicknameText && <BuiBanner label={nicknameText} width={'120%'} />}
+        {needCountText && <BuiBanner label={needCountText} width={'120%'} />}
+      </div>
+      <div className={styles.badges}>{props.badge}</div>
+    </CardActionArea>
+  </Card>;
+});

--- a/components/calculationInput/equipments/UpgradeConfirmationDialog.module.scss
+++ b/components/calculationInput/equipments/UpgradeConfirmationDialog.module.scss
@@ -2,7 +2,9 @@
 @use 'scss/flexbox.module';
 @use 'components/calculationInput/common/common-calculation-input-layout';
 
-.desc, .equip, .pieces {
+.desc,
+.equip,
+.pieces {
   @include layout.bui-option-child-content-margin;
 }
 
@@ -13,14 +15,12 @@
   align-content: center;
   align-items: center;
 
+  margin-top: 1em;
+
   user-select: none;
 
-  > :not(:last-child) {
-    margin-right: 1em;
-  }
-
   > * {
-    margin-top: 1em;
+    margin-inline: 0.5rem;
   }
 }
 

--- a/components/calculationInput/equipments/UpgradeConfirmationDialog.module.scss
+++ b/components/calculationInput/equipments/UpgradeConfirmationDialog.module.scss
@@ -1,0 +1,29 @@
+@use 'scss/layout.module';
+@use 'scss/flexbox.module';
+@use 'components/calculationInput/common/common-calculation-input-layout';
+
+.desc, .equip, .pieces {
+  @include layout.bui-option-child-content-margin;
+}
+
+.equip {
+  display: flex;
+
+  justify-items: center;
+  align-content: center;
+  align-items: center;
+
+  user-select: none;
+
+  > :not(:last-child) {
+    margin-right: 1em;
+  }
+
+  > * {
+    margin-top: 1em;
+  }
+}
+
+.card {
+  @include common-calculation-input-layout.items-list;
+}

--- a/components/calculationInput/equipments/UpgradeConfirmationDialog.tsx
+++ b/components/calculationInput/equipments/UpgradeConfirmationDialog.tsx
@@ -1,4 +1,4 @@
-import styles from "components/calculationInput/equipments/UpgradeConfirmationDialog.module.scss";
+import styles from 'components/calculationInput/equipments/UpgradeConfirmationDialog.module.scss';
 import {
   Button,
   Card,
@@ -9,129 +9,122 @@ import {
   DialogTitle,
   useMediaQuery,
   useTheme,
-} from "@mui/material";
-import Box from "@mui/material/Box";
-import React, { useCallback, useMemo } from "react";
-import { EquipmentInfoToEdit } from "stores/EquipmentsRequirementStore";
-import EquipmentCard from "components/bui/card/EquipmentCard";
-import { EquipmentsById } from "components/calculationInput/PiecesCalculationCommonTypes";
-import BuiLinedText from "components/bui/text/BuiLinedText";
-import { useTranslation } from "next-i18next";
-import { EquipmentsByTierAndCategory } from "components/calculationInput/equipments/EquipmentsInput";
-import { observer } from "mobx-react-lite";
-import { useStore } from "stores/WizStore";
-import { calculateRequirementAmount } from "components/calculationInput/equipments/inventory/piecesStateCalculator";
-import { ArrowForwardRounded } from "@mui/icons-material";
-import BuiBanner from "components/bui/BuiBanner";
-import { PieceState } from "./inventory/PiecesInventory";
-
-export interface IEquipmentFormInputs {
-  neededEquipmentsCount: string;
-  nickname: string;
-}
+} from '@mui/material';
+import Box from '@mui/material/Box';
+import React, {useCallback, useMemo} from 'react';
+import {EquipmentInfoToEdit} from 'stores/EquipmentsRequirementStore';
+import EquipmentCard from 'components/bui/card/EquipmentCard';
+import {EquipmentsById} from 'components/calculationInput/PiecesCalculationCommonTypes';
+import BuiLinedText from 'components/bui/text/BuiLinedText';
+import {useTranslation} from 'next-i18next';
+import {EquipmentsByTierAndCategory} from 'components/calculationInput/equipments/EquipmentsInput';
+import {observer} from 'mobx-react-lite';
+import {useStore} from 'stores/WizStore';
+import {calculateRequirementAmount} from 'components/calculationInput/equipments/inventory/piecesStateCalculator';
+import {ArrowForwardRounded} from '@mui/icons-material';
+import BuiBanner from 'components/bui/BuiBanner';
+import {PieceState} from './inventory/PiecesInventory';
 
 type UpgradeConfirmationDialogProps = {
-  isOpened: boolean;
-  equipmentsById: EquipmentsById;
-  equipmentsByTierAndCategory: EquipmentsByTierAndCategory;
-  handleUpgrade: (
-    equipmentInfoToEdit: EquipmentInfoToEdit,
-    requirements: PieceState[]
-  ) => void;
-  handleCancel: () => void;
-  equipmentInfoToEdit: EquipmentInfoToEdit;
+  open: boolean;
+  equipById: EquipmentsById;
+  equipByCategory: EquipmentsByTierAndCategory;
+  onUpgrade: (equip: EquipmentInfoToEdit, requirements: PieceState[]) => void;
+  onCancel: () => void;
+  equip: EquipmentInfoToEdit;
 };
 
 const UpgradeConfirmationDialog = ({
-  isOpened,
-  equipmentInfoToEdit,
-  equipmentsById,
-  equipmentsByTierAndCategory,
-  handleUpgrade: onUpgrade,
-  handleCancel: onCancel,
+  open,
+  equipById,
+  equipByCategory,
+  onUpgrade,
+  onCancel,
+  equip: equipInfo,
 }: UpgradeConfirmationDialogProps) => {
   const store = useStore();
-  const { t } = useTranslation("home");
+  const {t} = useTranslation('home');
   const theme = useTheme();
 
-  const isFullScreen = useMediaQuery(theme.breakpoints.down("md"));
+  const isFullScreen = useMediaQuery(theme.breakpoints.down('md'));
 
   const currentEquip = useMemo(() => {
-    return equipmentsById.get(equipmentInfoToEdit.currentEquipmentId);
-  }, [equipmentInfoToEdit.currentEquipmentId]);
+    return equipById.get(equipInfo.currentEquipmentId);
+  }, [equipById, equipInfo.currentEquipmentId]);
 
   const targetEquip = useMemo(() => {
-    return equipmentsById.get(equipmentInfoToEdit.targetEquipmentId);
-  }, [equipmentInfoToEdit.targetEquipmentId]);
+    return equipById.get(equipInfo.targetEquipmentId);
+  }, [equipById, equipInfo.targetEquipmentId]);
 
-  const {count, nickname} = equipmentInfoToEdit;
-
-  if (!currentEquip || !targetEquip) return <></>;
+  const {count, nickname} = equipInfo;
 
   const requirements = useMemo(() => {
+    if (!currentEquip || !targetEquip) return [];
     const requirements = Array.from(
-      calculateRequirementAmount(
-        equipmentsById,
-        equipmentsByTierAndCategory,
-        currentEquip.id,
-        targetEquip.id,
-        count
-      ).entries(),
-      ([pieceId, needCount]): { pieceId: string; state: PieceState } => {
-        const inStockCount =
+        calculateRequirementAmount(
+            equipById,
+            equipByCategory,
+            currentEquip.id,
+            targetEquip.id,
+            count
+        ).entries(),
+        ([pieceId, needCount]): { pieceId: string; state: PieceState } => {
+          const inStockCount =
           store.equipmentsRequirementStore.piecesInventory.get(pieceId)
-            ?.inStockCount ?? 0;
-        return { pieceId, state: { pieceId, needCount, inStockCount } };
-      }
+              ?.inStockCount ?? 0;
+          return {pieceId, state: {pieceId, needCount, inStockCount}};
+        }
     );
     return requirements
-      .sort((a, b) => (a.pieceId > b.pieceId ? -1 : 1))
-      .map(({ pieceId, state }) => ({
-        pieceId,
-        piece: equipmentsById.get(pieceId),
-        use: state.needCount,
-        stock: state.inStockCount,
-      }));
-  }, [currentEquip.id, targetEquip.id, count]);
+        .sort((a, b) => (a.pieceId > b.pieceId ? -1 : 1))
+        .map(({pieceId, state}) => ({
+          pieceId,
+          piece: equipById.get(pieceId),
+          use: state.needCount,
+          stock: state.inStockCount,
+        }));
+  }, [equipById, equipByCategory, currentEquip, targetEquip, count]);
 
   const handleUpgrade = useCallback(() => {
     onUpgrade(
-      equipmentInfoToEdit,
-      requirements.map(({ pieceId, use, stock }) => ({
-        pieceId,
-        needCount: use,
-        inStockCount: stock,
-      }))
+        equipInfo,
+        requirements.map(({pieceId, use, stock}) => ({
+          pieceId,
+          needCount: use,
+          inStockCount: stock,
+        }))
     );
-  }, [currentEquip.id, targetEquip.id, count, onUpgrade]);
+  }, [equipInfo, requirements, onUpgrade]);
 
   return (
-    <Dialog fullWidth open={isOpened} fullScreen={isFullScreen} keepMounted>
+    <Dialog fullWidth open={open} fullScreen={isFullScreen} keepMounted>
       <DialogTitle>
-        <Box>{t("upgradeDialog.title")}</Box>
+        <Box>{t('upgradeDialog.title')}</Box>
       </DialogTitle>
 
       <DialogContent>
         <Box className={styles.desc}>
-          {t("upgradeDialog.description_1")}
+          {t('upgradeDialog.description_1')}
           <br />
-          {t("upgradeDialog.description_2")}
+          {t('upgradeDialog.description_2')}
         </Box>
-        <BuiLinedText>{t("upgradeDialog.detail")}</BuiLinedText>
+        <BuiLinedText>{t('upgradeDialog.detail')}</BuiLinedText>
         <Box className={styles.equip}>
-          <EquipmentCard
+          {currentEquip && <EquipmentCard
             bottomLeftText={`T${currentEquip.tier}`}
-            imageName={currentEquip.icon} />
+            imageName={currentEquip.icon}
+          />}
           <ArrowForwardRounded fontSize="large" />
-          <EquipmentCard
+          {targetEquip && <EquipmentCard
             bottomLeftText={`T${targetEquip.tier}`}
-            imageName={targetEquip.icon} />
-            <span><BuiBanner label={`x${count}`} /></span>
-            <span>{nickname && <BuiBanner label={`${nickname}`} />}</span>
+            imageName={targetEquip.icon}
+          />}
+          <span><BuiBanner label={`x${count}`} /></span>
+          <span>{nickname && <BuiBanner label={`${nickname}`} />}</span>
         </Box>
-        <BuiLinedText>{t("upgradeDialog.pieces")}</BuiLinedText>
+        <BuiLinedText>{t('upgradeDialog.pieces')}</BuiLinedText>
         <Box className={styles.pieces}>
-          {requirements.map(({ piece, use, stock }, i) => (
+          {requirements.map(({piece, use, stock}, i) => (
             <Card key={i} elevation={1}>
               <CardActionArea>
                 <div className={styles.card}>
@@ -140,7 +133,7 @@ const UpgradeConfirmationDialog = ({
                       imageName={piece.icon}
                       bottomRightText={`x${stock}`} />
                   )}
-                  <BuiBanner label={`${use}`} width={"120%"} />
+                  <BuiBanner label={`${use}`} width={'120%'} />
                 </div>
               </CardActionArea>
             </Card>
@@ -149,8 +142,8 @@ const UpgradeConfirmationDialog = ({
       </DialogContent>
 
       <DialogActions>
-        <Button onClick={onCancel}>{t("cancelButton")}</Button>
-        <Button onClick={handleUpgrade}>{t("upgradeAndDeleteButton")}</Button>
+        <Button onClick={onCancel}>{t('cancelButton')}</Button>
+        <Button onClick={handleUpgrade}>{t('upgradeAndDeleteButton')}</Button>
       </DialogActions>
     </Dialog>
   );

--- a/components/calculationInput/equipments/UpgradeConfirmationDialog.tsx
+++ b/components/calculationInput/equipments/UpgradeConfirmationDialog.tsx
@@ -1,0 +1,178 @@
+/* eslint-disable max-len */
+import styles from "components/calculationInput/equipments/UpgradeConfirmationDialog.module.scss";
+import {
+  Button,
+  Card,
+  CardActionArea,
+  CircularProgress,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  Step,
+  StepButton,
+  StepContent,
+  Stepper,
+  Tooltip,
+  Typography,
+  useMediaQuery,
+  useTheme,
+} from "@mui/material";
+import Box from "@mui/material/Box";
+import React, { useCallback, useEffect, useMemo, useState } from "react";
+import {
+  EquipmentInfoToEdit,
+  IRequirementByEquipment,
+} from "stores/EquipmentsRequirementStore";
+import BuiButton from "components/bui/BuiButton";
+import { Equipment, EquipmentCompositionType } from "model/Equipment";
+import ItemsOnCurrentTier from "components/calculationInput/common/ItemsOnCurrentTier";
+import EquipmentCard from "components/bui/card/EquipmentCard";
+import { EquipmentsById } from "components/calculationInput/PiecesCalculationCommonTypes";
+import BuiLinedText from "components/bui/text/BuiLinedText";
+import TargetEquipmentSelection from "components/calculationInput/equipments/TargetEquipmentSelection";
+import { useForm } from "react-hook-form";
+import PositiveIntegerOnlyInput from "components/calculationInput/common/PositiveIntegerOnlyInput";
+import { useTranslation } from "next-i18next";
+import { usePrevious } from "common/hook";
+import {
+  EquipmentsByTierAndCategory,
+  hashTierAndCategoryKey,
+} from "components/calculationInput/equipments/EquipmentsInput";
+import NickNameInput from "components/calculationInput/equipments/EquipmentDialog/NickNameInput";
+import { observer } from "mobx-react-lite";
+import { useStore } from "stores/WizStore";
+import { calculateRequirementAmount } from "components/calculationInput/equipments/inventory/piecesStateCalculator";
+import { boolean } from "mobx-state-tree/dist/internal";
+import { ArrowForwardIosRounded, ArrowForwardRounded } from "@mui/icons-material";
+import BuiBanner from "components/bui/BuiBanner";
+import { PieceState } from "./inventory/PiecesInventory";
+
+export interface IEquipmentFormInputs {
+  neededEquipmentsCount: string;
+  nickname: string;
+}
+
+const neededEquipmentsCountField = "neededEquipmentsCount";
+const nicknameField = "nickname";
+
+type UpgradeConfirmationDialogProps = {
+  isOpened: boolean;
+  equipmentsById: EquipmentsById;
+  equipmentsByTierAndCategory: EquipmentsByTierAndCategory;
+  handleUpgrade: (
+    equipmentInfoToEdit: EquipmentInfoToEdit,
+    requirements: PieceState[]
+  ) => void;
+  handleCancel: () => void;
+  equipmentInfoToEdit: EquipmentInfoToEdit;
+};
+
+const UpgradeConfirmationDialog = ({
+  isOpened,
+  equipmentInfoToEdit,
+  equipmentsById,
+  equipmentsByTierAndCategory,
+  handleUpgrade: onUpgrade,
+  handleCancel: onCancel,
+}: UpgradeConfirmationDialogProps) => {
+  const store = useStore();
+  const { t } = useTranslation("home");
+  const theme = useTheme();
+
+  const isFullScreen = useMediaQuery(theme.breakpoints.down("md"));
+
+  const currentEquip = useMemo(() => {
+    return equipmentsById.get(equipmentInfoToEdit.currentEquipmentId);
+  }, [equipmentInfoToEdit.currentEquipmentId]);
+
+  const targetEquip = useMemo(() => {
+    return equipmentsById.get(equipmentInfoToEdit.targetEquipmentId);
+  }, [equipmentInfoToEdit.targetEquipmentId]);
+
+  const count = equipmentInfoToEdit.count;
+
+  if (!currentEquip || !targetEquip) return <></>;
+
+  const requirements = useMemo(() => {
+    const requirements = Array.from(
+      calculateRequirementAmount(
+        equipmentsById,
+        equipmentsByTierAndCategory,
+        currentEquip.id,
+        targetEquip.id,
+        count
+      ).entries(),
+      ([pieceId, needCount]): { pieceId: string; state: PieceState } => {
+        const inStockCount =
+          store.equipmentsRequirementStore.piecesInventory.get(pieceId)
+            ?.inStockCount ?? 0;
+        return { pieceId, state: { pieceId, needCount, inStockCount } };
+      }
+    );
+    return requirements
+      .sort((a, b) => (a.pieceId > b.pieceId ? -1 : 1))
+      .map(({ pieceId, state }) => ({
+        pieceId,
+        piece: equipmentsById.get(pieceId),
+        use: state.needCount,
+        stock: state.inStockCount,
+      }));
+  }, [currentEquip.id, targetEquip.id, count]);
+
+  const handleUpgrade = useCallback(() => {
+    onUpgrade(
+      equipmentInfoToEdit,
+      requirements.map(({pieceId, use, stock}) => ({pieceId, needCount: use, inStockCount: stock})),
+    );
+  }, [currentEquip.id, targetEquip.id, count, onUpgrade]);
+
+  return (
+    <Dialog fullWidth open={isOpened} fullScreen={isFullScreen} keepMounted>
+      <DialogTitle>
+        <Box>強化内容確認</Box>
+      </DialogTitle>
+
+      <DialogContent>
+        <Box className={styles.desc}>
+          装備設計図を消費し、以下の強化を行います。<br/>
+          ※登録されている所持設計図を必要数だけ減らして、この装備をリストから削除します。
+        </Box>
+        <BuiLinedText>強化内容</BuiLinedText>
+        <Box className={styles.equip}>
+          {/* <div style={{display: "inline-block"}}>
+            <BuiBanner label={`${equipmentInfoToEdit.nickname}`} />
+          </div> */}
+          <EquipmentCard
+            bottomLeftText={`T${currentEquip.tier}`}
+            imageName={currentEquip.icon} />
+          <ArrowForwardRounded />
+          <EquipmentCard
+            bottomLeftText={`T${targetEquip.tier}`}
+            imageName={targetEquip.icon} />
+          <div style={{display: "inline-block"}}>
+            <BuiBanner label={`x${equipmentInfoToEdit.count}`} />
+          </div>
+        </Box>
+        <BuiLinedText>消費される設計図</BuiLinedText>
+        <Box className={styles.pieces}>
+          {requirements.map(({ piece, use, stock }, i) => (
+            <Card key={i} elevation={1}>
+              <CardActionArea><div className={styles.card}>
+                {piece && <EquipmentCard imageName={piece.icon} bottomRightText={`x${stock}`} />}
+                <BuiBanner label={`${use}`} width={"120%"} />
+              </div></CardActionArea>
+            </Card>
+          ))}
+        </Box>
+      </DialogContent>
+
+      <DialogActions>
+        <Button onClick={onCancel}>{t("cancelButton")}</Button>
+        <Button onClick={handleUpgrade}>{t("upgradeAndDeleteButton")}</Button>
+      </DialogActions>
+    </Dialog>
+  );
+};
+
+export default observer(UpgradeConfirmationDialog);

--- a/components/calculationInput/equipments/UpgradeConfirmationDialog.tsx
+++ b/components/calculationInput/equipments/UpgradeConfirmationDialog.tsx
@@ -1,50 +1,27 @@
-/* eslint-disable max-len */
 import styles from "components/calculationInput/equipments/UpgradeConfirmationDialog.module.scss";
 import {
   Button,
   Card,
   CardActionArea,
-  CircularProgress,
   Dialog,
   DialogActions,
   DialogContent,
   DialogTitle,
-  Step,
-  StepButton,
-  StepContent,
-  Stepper,
-  Tooltip,
-  Typography,
   useMediaQuery,
   useTheme,
 } from "@mui/material";
 import Box from "@mui/material/Box";
-import React, { useCallback, useEffect, useMemo, useState } from "react";
-import {
-  EquipmentInfoToEdit,
-  IRequirementByEquipment,
-} from "stores/EquipmentsRequirementStore";
-import BuiButton from "components/bui/BuiButton";
-import { Equipment, EquipmentCompositionType } from "model/Equipment";
-import ItemsOnCurrentTier from "components/calculationInput/common/ItemsOnCurrentTier";
+import React, { useCallback, useMemo } from "react";
+import { EquipmentInfoToEdit } from "stores/EquipmentsRequirementStore";
 import EquipmentCard from "components/bui/card/EquipmentCard";
 import { EquipmentsById } from "components/calculationInput/PiecesCalculationCommonTypes";
 import BuiLinedText from "components/bui/text/BuiLinedText";
-import TargetEquipmentSelection from "components/calculationInput/equipments/TargetEquipmentSelection";
-import { useForm } from "react-hook-form";
-import PositiveIntegerOnlyInput from "components/calculationInput/common/PositiveIntegerOnlyInput";
 import { useTranslation } from "next-i18next";
-import { usePrevious } from "common/hook";
-import {
-  EquipmentsByTierAndCategory,
-  hashTierAndCategoryKey,
-} from "components/calculationInput/equipments/EquipmentsInput";
-import NickNameInput from "components/calculationInput/equipments/EquipmentDialog/NickNameInput";
+import { EquipmentsByTierAndCategory } from "components/calculationInput/equipments/EquipmentsInput";
 import { observer } from "mobx-react-lite";
 import { useStore } from "stores/WizStore";
 import { calculateRequirementAmount } from "components/calculationInput/equipments/inventory/piecesStateCalculator";
-import { boolean } from "mobx-state-tree/dist/internal";
-import { ArrowForwardIosRounded, ArrowForwardRounded } from "@mui/icons-material";
+import { ArrowForwardRounded } from "@mui/icons-material";
 import BuiBanner from "components/bui/BuiBanner";
 import { PieceState } from "./inventory/PiecesInventory";
 
@@ -52,9 +29,6 @@ export interface IEquipmentFormInputs {
   neededEquipmentsCount: string;
   nickname: string;
 }
-
-const neededEquipmentsCountField = "neededEquipmentsCount";
-const nicknameField = "nickname";
 
 type UpgradeConfirmationDialogProps = {
   isOpened: boolean;
@@ -90,7 +64,7 @@ const UpgradeConfirmationDialog = ({
     return equipmentsById.get(equipmentInfoToEdit.targetEquipmentId);
   }, [equipmentInfoToEdit.targetEquipmentId]);
 
-  const count = equipmentInfoToEdit.count;
+  const {count, nickname} = equipmentInfoToEdit;
 
   if (!currentEquip || !targetEquip) return <></>;
 
@@ -123,45 +97,52 @@ const UpgradeConfirmationDialog = ({
   const handleUpgrade = useCallback(() => {
     onUpgrade(
       equipmentInfoToEdit,
-      requirements.map(({pieceId, use, stock}) => ({pieceId, needCount: use, inStockCount: stock})),
+      requirements.map(({ pieceId, use, stock }) => ({
+        pieceId,
+        needCount: use,
+        inStockCount: stock,
+      }))
     );
   }, [currentEquip.id, targetEquip.id, count, onUpgrade]);
 
   return (
     <Dialog fullWidth open={isOpened} fullScreen={isFullScreen} keepMounted>
       <DialogTitle>
-        <Box>強化内容確認</Box>
+        <Box>{t("upgradeDialog.title")}</Box>
       </DialogTitle>
 
       <DialogContent>
         <Box className={styles.desc}>
-          装備設計図を消費し、以下の強化を行います。<br/>
-          ※登録されている所持設計図を必要数だけ減らして、この装備をリストから削除します。
+          {t("upgradeDialog.description_1")}
+          <br />
+          {t("upgradeDialog.description_2")}
         </Box>
-        <BuiLinedText>強化内容</BuiLinedText>
+        <BuiLinedText>{t("upgradeDialog.detail")}</BuiLinedText>
         <Box className={styles.equip}>
-          {/* <div style={{display: "inline-block"}}>
-            <BuiBanner label={`${equipmentInfoToEdit.nickname}`} />
-          </div> */}
           <EquipmentCard
             bottomLeftText={`T${currentEquip.tier}`}
             imageName={currentEquip.icon} />
-          <ArrowForwardRounded />
+          <ArrowForwardRounded fontSize="large" />
           <EquipmentCard
             bottomLeftText={`T${targetEquip.tier}`}
             imageName={targetEquip.icon} />
-          <div style={{display: "inline-block"}}>
-            <BuiBanner label={`x${equipmentInfoToEdit.count}`} />
-          </div>
+            <span><BuiBanner label={`x${count}`} /></span>
+            <span>{nickname && <BuiBanner label={`${nickname}`} />}</span>
         </Box>
-        <BuiLinedText>消費される設計図</BuiLinedText>
+        <BuiLinedText>{t("upgradeDialog.pieces")}</BuiLinedText>
         <Box className={styles.pieces}>
           {requirements.map(({ piece, use, stock }, i) => (
             <Card key={i} elevation={1}>
-              <CardActionArea><div className={styles.card}>
-                {piece && <EquipmentCard imageName={piece.icon} bottomRightText={`x${stock}`} />}
-                <BuiBanner label={`${use}`} width={"120%"} />
-              </div></CardActionArea>
+              <CardActionArea>
+                <div className={styles.card}>
+                  {piece && (
+                    <EquipmentCard
+                      imageName={piece.icon}
+                      bottomRightText={`x${stock}`} />
+                  )}
+                  <BuiBanner label={`${use}`} width={"120%"} />
+                </div>
+              </CardActionArea>
             </Card>
           ))}
         </Box>

--- a/components/calculationInput/equipments/inventory/PiecesInventory.tsx
+++ b/components/calculationInput/equipments/inventory/PiecesInventory.tsx
@@ -1,8 +1,5 @@
 import styles from './PiecesInventory.module.scss';
-import {Card, CardActionArea} from '@mui/material';
-import EquipmentCard from 'components/bui/card/EquipmentCard';
-import BuiBanner from 'components/bui/BuiBanner';
-import React, {useMemo, useState} from 'react';
+import React, {useCallback, useMemo, useState} from 'react';
 import {IPieceInventory} from 'stores/EquipmentsRequirementStore';
 import {EquipmentsById} from 'components/calculationInput/PiecesCalculationCommonTypes';
 import InventoryUpdateDialog, {
@@ -12,6 +9,8 @@ import BuiButton from 'components/bui/BuiButton';
 import {useStore} from 'stores/WizStore';
 import {observer} from 'mobx-react-lite';
 import {useTranslation} from 'next-i18next';
+import {LabeledEquipmentCard} from '../LabeledEquipmentCard';
+import {Done} from '@mui/icons-material';
 
 export type PieceState = IPieceInventory & {
   needCount: number;
@@ -31,25 +30,32 @@ const PiecesInventory = (
   const {t} = useTranslation('home');
   const store = useStore();
 
-  const pieces = useMemo(() =>
-    Array.from(piecesState.values()).sort((a, b) => a.pieceId>b.pieceId ? -1:1 ),
-  [piecesState]);
+  const pieces = useMemo(() => {
+    const pieces = Array.from(piecesState.values())
+        .sort((a, b) => a.pieceId>b.pieceId ? -1 : 1);
+    return [
+      ...pieces.filter((it) => it.needCount > it.inStockCount),
+      ...pieces.filter((it) => it.needCount <= it.inStockCount),
+    ];
+  }, [piecesState]);
   // Only pieces that have non 0 stock count are visible.
-  const homePageVisiblePieces = pieces.filter((piece) => piece.inStockCount > 0);
+  const homePageVisiblePieces = useMemo(() => {
+    return pieces.filter((piece) => piece.inStockCount > 0);
+  }, [pieces]);
   const [piecesToUpdate, setPiecesToUpdate] = useState(pieces);
   const [showAllPieces, setShowAllPieces] = useState(homePageVisiblePieces.length <= defaultMaxVisiblePiecesCount);
 
   const [isUpdateInventoryDialogOpened, setIsUpdateInventoryDialogOpened] = useState(false);
 
-  const openSinglePieceUpdateDialog = (inventory: PieceState) =>{
+  const openSinglePieceUpdateDialog = useCallback((_: unknown, inventory: PieceState) =>{
     setPiecesToUpdate([inventory]);
     setIsUpdateInventoryDialogOpened(true);
-  };
+  }, []);
 
-  const openAllInventoryUpdateDialog = () =>{
+  const openAllInventoryUpdateDialog = useCallback(() => {
     setPiecesToUpdate(pieces);
     setIsUpdateInventoryDialogOpened(true);
-  };
+  }, [pieces]);
 
   const handleCancelUpdateInventory = () => {
     setIsUpdateInventoryDialogOpened(false);
@@ -67,6 +73,10 @@ const PiecesInventory = (
     return homePageVisiblePieces.slice(0, defaultMaxVisiblePiecesCount);
   };
 
+  const checkBadge = useMemo(() => {
+    return <Done />;
+  }, []);
+
   return <>
     {
       isUpdateInventoryDialogOpened ? <InventoryUpdateDialog pieces={piecesToUpdate}
@@ -75,23 +85,17 @@ const PiecesInventory = (
         equipmentsById={equipmentsById}
         isOpened={isUpdateInventoryDialogOpened} /> : null
     }
-    {
-      computeMaximumPiecesToShow().map((inventory, index) => {
-        if (inventory.inStockCount <= 0) return null;
-        const piece = equipmentsById.get(inventory.pieceId);
-        if (!piece) return null;
+    {computeMaximumPiecesToShow().map((inventory, index) => {
+      if (inventory.inStockCount <= 0) return null;
 
-        return <Card key={index} elevation={1}
-          onClick={() => openSinglePieceUpdateDialog(inventory)}>
-          <CardActionArea>
-            <div className={styles.piecesList}>
-              <EquipmentCard imageName={piece.icon} bottomRightText={`x${inventory.inStockCount}`}/>
-              <BuiBanner label={inventory.needCount.toString()} width={'120%'} />
-            </div>
-          </CardActionArea>
-        </Card>;
-      })
-    }
+      const enough = inventory.needCount <= inventory.inStockCount;
+
+      return <LabeledEquipmentCard key={index} index={inventory}
+        showStockCount showNeedCount
+        onClick={openSinglePieceUpdateDialog}
+        equipById={equipmentsById} pieceState={inventory}
+        badge={enough ? checkBadge : undefined} />;
+    })}
     {
       homePageVisiblePieces.length > defaultMaxVisiblePiecesCount ? <div className={styles.editButton}>
         <BuiButton variant={'text'} color={'baTextButtonPrimary'} onClick={toggleShowAllPieces}

--- a/components/calculationInput/equipments/inventory/PiecesInventory.tsx
+++ b/components/calculationInput/equipments/inventory/PiecesInventory.tsx
@@ -31,16 +31,14 @@ const PiecesInventory = (
   const store = useStore();
 
   const pieces = useMemo(() => {
-    const pieces = Array.from(piecesState.values())
-        .sort((a, b) => a.pieceId>b.pieceId ? -1 : 1);
-    return [
-      ...pieces.filter((it) => it.needCount > it.inStockCount),
-      ...pieces.filter((it) => it.needCount <= it.inStockCount),
-    ];
+    return Array.from(piecesState.values())
+        .sort((a, b) => a.pieceId > b.pieceId ? -1 : 1);
   }, [piecesState]);
   // Only pieces that have non 0 stock count are visible.
   const homePageVisiblePieces = useMemo(() => {
-    return pieces.filter((piece) => piece.inStockCount > 0);
+    const ordering = (piece: PieceState) => piece.needCount <= piece.inStockCount ? 1 : 0;
+    return pieces.filter((piece) => piece.inStockCount > 0)
+        .sort((a, b) => ordering(a) - ordering(b));
   }, [pieces]);
   const [piecesToUpdate, setPiecesToUpdate] = useState(pieces);
   const [showAllPieces, setShowAllPieces] = useState(homePageVisiblePieces.length <= defaultMaxVisiblePiecesCount);

--- a/components/calculationInput/equipments/inventory/piecesStateCalculator.ts
+++ b/components/calculationInput/equipments/inventory/piecesStateCalculator.ts
@@ -70,6 +70,6 @@ export const checkRequirementsSatisfied = (
   return Array.from(requirements.entries())
       .every(([pieceId, need]) => {
         const stock = piecesState.get(pieceId)?.inStockCount ?? 0;
-        return need < stock;
+        return need <= stock;
       });
 };

--- a/components/calculationInput/equipments/inventory/piecesStateCalculator.ts
+++ b/components/calculationInput/equipments/inventory/piecesStateCalculator.ts
@@ -6,34 +6,55 @@ import {
 import {EquipmentsById} from 'components/calculationInput/PiecesCalculationCommonTypes';
 import {IWizStore} from 'stores/WizStore';
 
+export const calculateRequirementAmount = (
+  equipById: EquipmentsById,
+  equipByCategory: EquipmentsByTierAndCategory,
+  baseId: string,
+  targetId: string,
+  count: number,
+): Map<string, number> => {
+  const result: Map<string, number> = new Map();
+
+  const base = equipById.get(baseId);
+  const target = equipById.get(targetId);
+  if (!base || !target) return result;
+  const category = base.category;
+
+  for (let tier = base.tier + 1; tier <= target.tier; tier++) {
+    const equip = equipByCategory.get(hashTierAndCategoryKey({tier, category}));
+
+    if (!equip || !equip.recipe) continue;
+    for (const recipe of equip.recipe) {
+      result.set(recipe.id, (result.get(recipe.id) ?? 0) + recipe.count * count);
+    }
+  }
+
+  return result;
+};
+
 export const calculatePiecesState = (store: IWizStore, equipmentsById: EquipmentsById,
     equipmentsByTierAndCategory: EquipmentsByTierAndCategory) => {
   const piecesStateMap: Map<string, PieceState> = new Map();
   if (!equipmentsById) return piecesStateMap;
 
   for (const requirement of store.equipmentsRequirementStore.requirementByEquipments) {
-    const base = equipmentsById.get(requirement.currentEquipmentId);
-    const target = equipmentsById.get(requirement.targetEquipmentId);
-    if (!base || !target) continue;
-    for (let tier = base.tier+1; tier <= target.tier; tier++) {
-      const category = base.category;
-      const equip = equipmentsByTierAndCategory.get(hashTierAndCategoryKey({tier, category}));
+    calculateRequirementAmount(
+      equipmentsById,
+      equipmentsByTierAndCategory,
+      requirement.currentEquipmentId,
+      requirement.targetEquipmentId,
+      requirement.count,
+    ).forEach((amount, pieceId) => {
+      const pieceState = piecesStateMap.get(pieceId) ?? {
+        pieceId,
+        needCount: 0,
+        inStockCount: store.equipmentsRequirementStore
+          .piecesInventory.get(pieceId)?.inStockCount ?? 0,
+      };
 
-      if (!equip || !equip.recipe) continue;
-      for (const recipe of equip.recipe) {
-        const pieceState = piecesStateMap.get(recipe.id);
-        if (pieceState) {
-          pieceState.needCount += recipe.count * requirement.count;
-        } else {
-          const stock = store.equipmentsRequirementStore.piecesInventory.get(recipe.id)?.inStockCount ?? 0;
-          piecesStateMap.set(recipe.id, {
-            pieceId: recipe.id,
-            needCount: recipe.count * requirement.count,
-            inStockCount: stock,
-          });
-        }
-      }
-    }
+      pieceState.needCount += amount;
+      piecesStateMap.set(pieceId, pieceState);
+    })
   }
 
   return piecesStateMap;

--- a/components/calculationInput/equipments/inventory/piecesStateCalculator.ts
+++ b/components/calculationInput/equipments/inventory/piecesStateCalculator.ts
@@ -7,11 +7,11 @@ import {EquipmentsById} from 'components/calculationInput/PiecesCalculationCommo
 import {IWizStore} from 'stores/WizStore';
 
 export const calculateRequirementAmount = (
-  equipById: EquipmentsById,
-  equipByCategory: EquipmentsByTierAndCategory,
-  baseId: string,
-  targetId: string,
-  count: number,
+    equipById: EquipmentsById,
+    equipByCategory: EquipmentsByTierAndCategory,
+    baseId: string,
+    targetId: string,
+    count: number,
 ): Map<string, number> => {
   const result: Map<string, number> = new Map();
 
@@ -39,15 +39,15 @@ export const calculatePiecesState = (store: IWizStore, equipmentsById: Equipment
 
   for (const requirement of store.equipmentsRequirementStore.requirementByEquipments) {
     calculateRequirementAmount(
-      equipmentsById,
-      equipmentsByTierAndCategory,
-      requirement.currentEquipmentId,
-      requirement.targetEquipmentId,
-      requirement.count,
+        equipmentsById,
+        equipmentsByTierAndCategory,
+        requirement.currentEquipmentId,
+        requirement.targetEquipmentId,
+        requirement.count,
     ).forEach((amount, pieceId) => {
       const stock =
         store.equipmentsRequirementStore.piecesInventory.get(pieceId)
-          ?.inStockCount ?? 0;
+            ?.inStockCount ?? 0;
       const pieceState = piecesStateMap.get(pieceId) ?? {
         pieceId,
         needCount: 0,

--- a/components/calculationInput/equipments/inventory/piecesStateCalculator.ts
+++ b/components/calculationInput/equipments/inventory/piecesStateCalculator.ts
@@ -45,16 +45,18 @@ export const calculatePiecesState = (store: IWizStore, equipmentsById: Equipment
       requirement.targetEquipmentId,
       requirement.count,
     ).forEach((amount, pieceId) => {
+      const stock =
+        store.equipmentsRequirementStore.piecesInventory.get(pieceId)
+          ?.inStockCount ?? 0;
       const pieceState = piecesStateMap.get(pieceId) ?? {
         pieceId,
         needCount: 0,
-        inStockCount: store.equipmentsRequirementStore
-          .piecesInventory.get(pieceId)?.inStockCount ?? 0,
+        inStockCount: stock,
       };
 
       pieceState.needCount += amount;
       piecesStateMap.set(pieceId, pieceState);
-    })
+    });
   }
 
   return piecesStateMap;

--- a/public/locales/en/home.json
+++ b/public/locales/en/home.json
@@ -11,6 +11,7 @@
   "closeButton": "Close",
   "showAllButton": "Show All",
   "showFewerButton": "Show Fewer",
+  "canUpgradeBadge": "Upgradable",
   "isInADropCampaign": "In a drop Campaign?(Mission Normal)",
   "normal1x": "1x(No Campaign)",
   "normal2x": "Double",

--- a/public/locales/en/home.json
+++ b/public/locales/en/home.json
@@ -5,6 +5,8 @@
   "listButton": "List",
   "cancelButton": "Cancel",
   "deleteButton": "Delete",
+  "upgradeAndDeleteButton": "Upgrade & Delete",
+  "upgradeAndDeleteTooltip": "Consume pieces and delete this",
   "editButton": "Edit",
   "closeButton": "Close",
   "showAllButton": "Show All",
@@ -45,6 +47,13 @@
     "maxLengthIs": "Maximum characters are {{max}}",
     "enterNickName":  "Enter a nickname(optional)",
     "enterNickNameNormalHelperText": "Enter a student name to help you memorize equipment ownership"
+  },
+  "upgradeDialog": {
+    "title": "Upgrade Equipment",
+    "description_1": "Consume pieces and upgrade the following equipment.",
+    "description_2": "This reduces the quantity of pieces used from the registered inventory and removes this equipment from the list.",
+    "detail": "Upgrade details",
+    "pieces": "Pieces to be consumed"
   },
   "thinsToNote": {
     "title": "Things to note",

--- a/public/locales/ja/home.json
+++ b/public/locales/ja/home.json
@@ -11,6 +11,7 @@
   "closeButton": "閉じる",
   "showAllButton": "すべてを表示",
   "showFewerButton": "一部のみ表示",
+  "canUpgradeBadge": "強化可能",
   "isInADropCampaign": "Normalドロップ量キャンペーン中？",
   "normal1x": "キャンペーン無し（1倍）",
   "normal2x": "2倍",

--- a/public/locales/ja/home.json
+++ b/public/locales/ja/home.json
@@ -5,6 +5,8 @@
   "listButton": "検索",
   "cancelButton": "キャンセル",
   "deleteButton": "削除",
+  "upgradeAndDeleteButton": "強化＆削除",
+  "upgradeAndDeleteTooltip": "設計図を消費し、リストから削除します",
   "editButton": "編集",
   "closeButton": "閉じる",
   "showAllButton": "すべてを表示",

--- a/public/locales/ja/home.json
+++ b/public/locales/ja/home.json
@@ -47,6 +47,13 @@
     "enterNickName":  "ニックネーム入力（任意）",
     "enterNickNameNormalHelperText": "生徒の名前をメモとして入力すれば、装備の管理ができます"
   },
+  "upgradeDialog": {
+    "title": "強化内容確認",
+    "description_1": "装備設計図を消費し、以下の強化を行います。",
+    "description_2": "※登録されている所持設計図を必要数だけ減らして、この装備をリストから削除します。",
+    "detail": "強化内容",
+    "pieces": "消費される設計図"
+  },
   "thinsToNote": {
     "title": "注記",
     "pointThisIsEstimation": "推奨掃討回数は予測であり、実際の報酬と大きく異なる場合もあります。",

--- a/public/locales/zh/home.json
+++ b/public/locales/zh/home.json
@@ -11,6 +11,7 @@
   "closeButton": "关闭",
   "showAllButton": "显示全部",
   "showFewerButton": "收起",
+  "canUpgradeBadge": "强化可能",
   "isInADropCampaign": "N图掉落翻倍？",
   "normal1x": "1倍(N1)",
   "normal2x": "2倍(N2)",

--- a/public/locales/zh/home.json
+++ b/public/locales/zh/home.json
@@ -5,6 +5,8 @@
   "listButton": "列出",
   "cancelButton": "取消",
   "deleteButton": "删除",
+  "upgradeAndDeleteButton": "强化和移除",
+  "upgradeAndDeleteTooltip": "消耗设计图并将其从列表中删除",
   "editButton": "编辑",
   "closeButton": "关闭",
   "showAllButton": "显示全部",
@@ -44,6 +46,13 @@
     "maxLengthIs": "最多输入{{max}}个字",
     "enterNickName":  "添加昵称（选填）",
     "enterNickNameNormalHelperText": "可以输入学生姓名方便记和进行装备管理"
+  },
+  "upgradeDialog": {
+    "title": "确认强化细节",
+    "description_1": "消耗设备设计图以强化以下功能",
+    "description_2": "按要求减少已登记的占有权设计图数量，并将该装备从列表中删除。",
+    "detail": "确认强化细节",
+    "pieces": "消耗设计图"
   },
   "thinsToNote": {
     "title": "注意事项",


### PR DESCRIPTION
Added `Upgrade&Delete` button next to the `Delete` button of the Select Equipment dialog.
This button can be pressed when there are sufficient upgrade materials.
Once the upgrade is performed, the materials used are removed from the inventory and the equipment is removed from the list.

There seems to be a bug where editing inventory is not reflected on the DOM. Reloading the page fixes it, so stored values are seemed correct.

I'll leave it as a draft because I haven't finished translating or testing.