### PR TITLE
Change input type to number

### DIFF
--- a/components/calculationInput/common/PositiveIntegerOnlyInput.tsx
+++ b/components/calculationInput/common/PositiveIntegerOnlyInput.tsx
@@ -10,12 +10,13 @@ interface PositiveIntegerOnlyInputProps<T extends FieldValues> {
   showError: boolean;
   helperText: string;
   min?: number;
+  max?: number;
   inputLabel?: string;
 }
 
-const PositiveIntegerOnlyInput = function<T>({
+const PositiveIntegerOnlyInput = function<T extends FieldValues>({
   name, control, showError, helperText,
-  min = 1, inputLabel,
+  min = 1, max = 999, inputLabel,
 }: PositiveIntegerOnlyInputProps<T>) {
   const {t} = useTranslation('home');
   return <Controller
@@ -32,11 +33,11 @@ const PositiveIntegerOnlyInput = function<T>({
       },
       min: {
         value: min,
-        message: t('addPieceDialog.minimumIs', {min: 1}),
+        message: t('addPieceDialog.minimumIs', {min}),
       },
       max: {
-        value: 999,
-        message: t('addPieceDialog.maximumIs', {max: 999}),
+        value: max,
+        message: t('addPieceDialog.maximumIs', {max}),
       },
     }}
     render={({field}) => (
@@ -46,6 +47,8 @@ const PositiveIntegerOnlyInput = function<T>({
         variant="outlined"
         error={showError}
         helperText={helperText}
+        type='number'
+        autoComplete='off'
         label={inputLabel ?? t('addPieceDialog.quantity')}
       />
     )}


### PR DESCRIPTION
Changed form input type to `number`, disabled autocomplete, and added an ability to set a max value.
These changes are intended to allow to increase/decrease input value with the up/down keys.

However, with this change, the input no longer accepts full-width numbers. It just erase those characters and there's no helpful errors.
I think this behavior change isn't so bad, but if you don't think so, reject this.