### PR TITLE
Add feature to add sweeping results to inventory

### DIFF
--- a/common/randomId.ts
+++ b/common/randomId.ts
@@ -1,0 +1,4 @@
+export const randomId = (n = 18) => {
+  const bytes = String.fromCharCode(...Array.from(crypto.getRandomValues(new Uint8Array(n))));
+  return window.btoa(bytes);
+};

--- a/common/sortUtils.ts
+++ b/common/sortUtils.ts
@@ -1,3 +1,4 @@
+/* eslint-disable valid-jsdoc */
 import {isNumber} from 'common/checkVariableTypeUtil';
 
 export enum SortingOrder{
@@ -22,4 +23,82 @@ export const sortTwoUnknownValues = (valueA: unknown, valueB: unknown,
   }
 };
 
+type Comparator<Item> = (a: Item, b: Item) => number;
 
+const Ordering = {
+  /** They are equals. */
+  Equal: 0,
+  /** The first value is sorted after the second. */
+  First: +1,
+  /** The second value is sorted after the first. */
+  Second: -1,
+} as const;
+
+const isNully = (x: unknown): x is null | undefined => {
+  return x === null || x === undefined;
+};
+
+/**
+ * @param keySelector
+ *  A mapping function to extract key from an array element.
+ *  Note that this function can return null or undefined,
+ *  but these values are treated as greater than other values.
+ * @param comparatorFn
+ *  This comparator functions are applied in order, starting with the first,
+ *  and if the previous returns 0, the next is applied.
+ *  When all functions s return 0, it means the two elements are equal.
+ * @return a comparator function.
+ */
+export const buildComparator = <Item, Key>(
+  keySelector: (item: Item) => (Key | null | undefined),
+  ...comparatorFn: Comparator<Key>[]
+): Comparator<Item> => {
+  return (firstItem, secondItem) => {
+    if (firstItem === secondItem) return Ordering.Equal;
+    const first = keySelector(firstItem);
+    const second = keySelector(secondItem);
+    if (first === second) return Ordering.Equal;
+
+    if (isNully(first) || isNully(second)) {
+      return (first === second) ? Ordering.Equal :
+        isNully(first) ? Ordering.First :
+        isNully(second) ? Ordering.Second :
+        'unreachable' as never;
+    }
+
+    for (const comparator of comparatorFn) {
+      const ordering = comparator(first, second);
+      if (ordering != Ordering.Equal) return ordering;
+    }
+
+    return Ordering.Equal;
+  };
+};
+
+const numberAscending: Comparator<number> = (a, b) => a - b;
+const numberDescending: Comparator<number> = (a, b) => b - a;
+const stringAscending: Comparator<string> = (a, b) => a.localeCompare(b);
+const stringDescending: Comparator<string> = (a, b) => b.localeCompare(a);
+const numericStringAscending = buildComparator(parseFloat, numberAscending);
+const numericStringDescending = buildComparator(parseFloat, numberDescending);
+export const Comparators = {
+  numberAscending, numberDescending,
+  stringAscending, stringDescending,
+  numericStringAscending, numericStringDescending,
+} as const;
+
+export const buildArrayIndexComparator = <Item>(
+  array: readonly Item[],
+  order: SortingOrder = SortingOrder.Ascending,
+) => {
+  const comparator = order === SortingOrder.Ascending ?
+    Comparators.numberAscending :
+    Comparators.numberDescending;
+  return buildComparator<Item, number>(
+      (item) => {
+        const index = array.indexOf(item);
+        return index >= 0 ? index : null;
+      },
+      comparator,
+  );
+};

--- a/components/Home.tsx
+++ b/components/Home.tsx
@@ -9,7 +9,9 @@ import {Equipment, EquipmentCompositionType} from 'model/Equipment';
 import {Campaign} from 'model/Campaign';
 import RecommendedCampaigns from 'components/calculationResult/RecommendedCampaigns';
 import CalculationInputCard from 'components/calculationInput/CalculationInputCard';
-import {CampaignsById, EquipmentsById} from 'components/calculationInput/PiecesCalculationCommonTypes';
+import {
+  CampaignsById, EquipmentsById,
+} from 'components/calculationInput/PiecesCalculationCommonTypes';
 import useSWR from 'swr';
 import RecommendationsSummary from 'components/calculationResult/RecommendationsSummary';
 import IgnoredCampaigns from 'components/calculationResult/IgnoredCampaigns';
@@ -23,7 +25,10 @@ import {
   hashTierAndCategoryKey,
 } from 'components/calculationInput/equipments/EquipmentsInput';
 import {PieceState} from 'components/calculationInput/equipments/inventory/PiecesInventory';
-import {calculatePiecesState} from 'components/calculationInput/equipments/inventory/piecesStateCalculator';
+import {calculatePiecesState}
+  from 'components/calculationInput/equipments/inventory/piecesStateCalculator';
+import {AddToInventoryDialogContextProvider}
+  from './calculationInput/equipments/inventory/AddToInventoryDialog';
 
 const Home: NextPage = observer((props) => {
   const store = useStore();
@@ -150,10 +155,10 @@ const Home: NextPage = observer((props) => {
       onSetSolution={onSetSolution}
     />
 
-    {
-      store.equipmentsRequirementStore.resultMode === ResultMode.LinearProgram ?
-          buildLinearProgrammingSolution() : buildListStageOnlyResult()
-    }
+    <AddToInventoryDialogContextProvider equipById={equipmentsById} piecesState={piecesState}>
+      {store.equipmentsRequirementStore.resultMode === ResultMode.LinearProgram ?
+        buildLinearProgrammingSolution() : buildListStageOnlyResult()}
+    </AddToInventoryDialogContextProvider>
   </>;
 });
 

--- a/components/Home.tsx
+++ b/components/Home.tsx
@@ -120,14 +120,15 @@ const Home: NextPage = observer((props) => {
         equipmentsById={equipmentsById}
         equipmentsRequirementStore={store.equipmentsRequirementStore}
         normalMissionItemDropRatio={store.gameInfoStore.normalMissionItemDropRatio}
-        onCloseInEfficacyDialog={handleCloseInEfficacyDialog}/>
+        onCloseInEfficacyDialog={handleCloseInEfficacyDialog}
+        piecesState={piecesState} />
       <IgnoredCampaigns
         solution={solution}
         allCampaigns={campaigns}
         allRequiredPieceIds={store.equipmentsRequirementStore.getAllRequiredPieceIds()}
         equipmentsById={equipmentsById}
         gameServer={store.gameInfoStore.gameServer}
-      />
+        piecesState={piecesState} />
     </React.Fragment>;
   };
 

--- a/components/calculationInput/common/PositiveIntegerOnlyInput.tsx
+++ b/components/calculationInput/common/PositiveIntegerOnlyInput.tsx
@@ -1,22 +1,27 @@
-import {TextField} from '@mui/material';
+import {TextField, TextFieldProps} from '@mui/material';
 import {Controller, FieldValues, Path} from 'react-hook-form';
 import React from 'react';
 import {useTranslation} from 'next-i18next';
 import {Control} from 'react-hook-form/dist/types/form';
 
-interface PositiveIntegerOnlyInputProps<T extends FieldValues> {
+interface PositiveIntegerOnlyInputProps<T extends FieldValues>
+  extends Omit<TextFieldProps,
+    | 'inputProps' | 'variant' | 'error' | 'helperText' | 'label'
+    | 'onChange' | 'onBlur' | 'value' | 'name' | 'ref'>
+{
   name: Path<T>;
   control: Control<T>;
   showError: boolean;
   helperText: string;
   min?: number;
   inputLabel?: string;
-  focused?: boolean;
+  required?: boolean;
 }
 
-const PositiveIntegerOnlyInput = function<T>({
+const PositiveIntegerOnlyInput = function<T extends FieldValues>({
   name, control, showError, helperText,
-  min = 1, inputLabel, focused,
+  min = 1, inputLabel, required = true,
+  ...others
 }: PositiveIntegerOnlyInputProps<T>) {
   const {t} = useTranslation('home');
   return <Controller
@@ -24,7 +29,7 @@ const PositiveIntegerOnlyInput = function<T>({
     control={control}
     rules={{
       required: {
-        value: true,
+        value: required,
         message: t('addPieceDialog.required'),
       },
       pattern: {
@@ -40,10 +45,11 @@ const PositiveIntegerOnlyInput = function<T>({
         message: t('addPieceDialog.maximumIs', {max: 999}),
       },
     }}
-    render={({field}) => (
+    render={({field: {ref: fieldRef, ...field}}) => (
       <TextField
+        {...others}
         {...field}
-        inputRef={(elm) => elm && focused && elm.focus()}
+        inputRef={fieldRef}
         inputProps={{pattern: '\\d*'}}
         variant="outlined"
         error={showError}

--- a/components/calculationInput/common/PositiveIntegerOnlyInput.tsx
+++ b/components/calculationInput/common/PositiveIntegerOnlyInput.tsx
@@ -11,11 +11,12 @@ interface PositiveIntegerOnlyInputProps<T extends FieldValues> {
   helperText: string;
   min?: number;
   inputLabel?: string;
+  focused?: boolean;
 }
 
 const PositiveIntegerOnlyInput = function<T>({
   name, control, showError, helperText,
-  min = 1, inputLabel,
+  min = 1, inputLabel, focused,
 }: PositiveIntegerOnlyInputProps<T>) {
   const {t} = useTranslation('home');
   return <Controller
@@ -42,6 +43,7 @@ const PositiveIntegerOnlyInput = function<T>({
     render={({field}) => (
       <TextField
         {...field}
+        inputRef={(elm) => elm && focused && elm.focus()}
         inputProps={{pattern: '\\d*'}}
         variant="outlined"
         error={showError}

--- a/components/calculationInput/equipments/inventory/AddToInventoryDialog.module.scss
+++ b/components/calculationInput/equipments/inventory/AddToInventoryDialog.module.scss
@@ -1,0 +1,22 @@
+@use 'components/calculationInput/common/common-calculation-input-layout';
+
+.container {
+  display: grid;
+  justify-content: center;
+  grid-template-columns: repeat(auto-fill, 350px);
+  grid-gap: 10px;
+}
+
+.xs {
+  grid-template-columns: repeat(auto-fill, 300px);
+}
+
+.equipmentInputContainer {
+  display: flex;
+  margin: 10px;
+  align-items: center;
+}
+
+.equipmentCard {
+  @include common-calculation-input-layout.items-list;
+}

--- a/components/calculationInput/equipments/inventory/AddToInventoryDialog.tsx
+++ b/components/calculationInput/equipments/inventory/AddToInventoryDialog.tsx
@@ -1,0 +1,104 @@
+import styles from './AddToInventoryDialog.module.scss';
+import {Button, Dialog, DialogActions, DialogContent, DialogTitle, useMediaQuery, useTheme} from '@mui/material';
+import React, {useEffect, useMemo} from 'react';
+import {useTranslation} from 'next-i18next';
+import {useForm} from 'react-hook-form';
+import {DropPieceIdWithProbAndCount, EquipmentsById} from 'components/calculationInput/PiecesCalculationCommonTypes';
+import {InventoryForm} from './InventoryUpdateDialog';
+import ObtainedPieceBox from './ObtainedPieceBox';
+import {EquipmentsByTierAndCategory} from '../EquipmentsInput';
+import {useStore} from 'stores/WizStore';
+import {PieceState} from './PiecesInventory';
+
+const AddToInventoryDialog = ({
+  open,
+  drops,
+  equipById,
+  piecesState,
+  onCancel,
+  onUpdate,
+}: {
+  open: boolean,
+  drops: DropPieceIdWithProbAndCount[],
+  equipById: EquipmentsById,
+  piecesState: Map<string, PieceState>,
+  onCancel: () => void,
+  onUpdate: (formValues: InventoryForm) => void,
+}) => {
+  const store = useStore();
+  const {t} = useTranslation('home');
+  const theme = useTheme();
+
+  const pieceIds = useMemo(() => drops.map((drop) => drop.id), [drops]);
+  const pieces = useMemo(() => {
+    return Array.from(piecesState.values())
+        .filter((state) => pieceIds.includes(state.pieceId) && state.needCount > 0);
+  }, [piecesState, pieceIds]);
+  const defaultValues = useMemo(() => {
+    return pieces.reduce<InventoryForm>((acc, piece) => {
+      acc[piece.pieceId] = '';
+      return acc;
+    }, {});
+  }, [pieces]);
+
+  const {
+    control,
+    formState: {isValid: isCountValid, errors: allErrors},
+    getValues,
+    reset,
+  } = useForm<InventoryForm>({
+    mode: 'onChange',
+    defaultValues,
+  });
+
+  useEffect(() => {
+    open && reset();
+  }, [open, reset]);
+
+  const handleCancelDialog = () => {
+    onCancel();
+  };
+
+  const handleUpdateInventory = () => {
+    onUpdate(getValues());
+    const inventory = Object.entries(getValues()).reduce<InventoryForm>((acc, [id, value]) => {
+      const count = parseInt(value);
+      const stock = piecesState.get(id)?.inStockCount;
+      count && stock && (acc[id] = `${count + stock}`);
+      return acc;
+    }, {});
+    store.equipmentsRequirementStore.updateInventory(inventory);
+  };
+
+  const isFullScreen = useMediaQuery(theme.breakpoints.down('md'));
+  const isXsOrSmallerScreen = useMediaQuery(theme.breakpoints.down('sm'));
+  const hasManyPieces = () => pieces.length > 3;
+
+  return <Dialog open={open} keepMounted fullWidth
+    fullScreen={hasManyPieces() && isFullScreen}
+    maxWidth={hasManyPieces() && 'xl'}>
+    <DialogTitle>獲得した設計図</DialogTitle>
+
+    <DialogContent className={styles.dialogContentContainer}>
+      <div className={styles.filler}></div>
+      <div className={`${styles.container} ${isXsOrSmallerScreen && styles.xs}`}>
+        {pieces.map((piece) => {
+          return <ObtainedPieceBox key={piece.pieceId} allErrors={allErrors}
+            control={control}
+            equipmentsById={equipById}
+            piece={piece}/>;
+        })}
+      </div>
+      <div className={styles.filler}></div>
+    </DialogContent>
+
+    <DialogActions>
+      <Button onClick={handleCancelDialog}>{t('cancelButton')}</Button>
+      <Button onClick={handleUpdateInventory} disabled={!isCountValid}>
+        追加
+      </Button>
+    </DialogActions>
+  </Dialog>;
+};
+
+export default AddToInventoryDialog;

--- a/components/calculationInput/equipments/inventory/AddToInventoryDialog.tsx
+++ b/components/calculationInput/equipments/inventory/AddToInventoryDialog.tsx
@@ -1,12 +1,11 @@
 import styles from './AddToInventoryDialog.module.scss';
 import {Button, Dialog, DialogActions, DialogContent, DialogTitle, useMediaQuery, useTheme} from '@mui/material';
-import React, {useEffect, useMemo} from 'react';
+import React, {useEffect, useMemo, useReducer} from 'react';
 import {useTranslation} from 'next-i18next';
 import {useForm} from 'react-hook-form';
 import {DropPieceIdWithProbAndCount, EquipmentsById} from 'components/calculationInput/PiecesCalculationCommonTypes';
 import {InventoryForm} from './InventoryUpdateDialog';
 import ObtainedPieceBox from './ObtainedPieceBox';
-import {EquipmentsByTierAndCategory} from '../EquipmentsInput';
 import {useStore} from 'stores/WizStore';
 import {PieceState} from './PiecesInventory';
 
@@ -28,6 +27,12 @@ const AddToInventoryDialog = ({
   const store = useStore();
   const {t} = useTranslation('home');
   const theme = useTheme();
+
+  // hack to lazy rendering
+  const [onceOpen, notifyOpened] = useReducer((x) => true, false);
+  useEffect(() => {
+    open && notifyOpened();
+  }, [open]);
 
   const pieceIds = useMemo(() => drops.map((drop) => drop.id), [drops]);
   const pieces = useMemo(() => {
@@ -51,30 +56,28 @@ const AddToInventoryDialog = ({
     defaultValues,
   });
 
-  useEffect(() => {
-    open && reset();
-  }, [open, reset]);
-
   const handleCancelDialog = () => {
     onCancel();
+    reset();
   };
 
   const handleUpdateInventory = () => {
     onUpdate(getValues());
     const inventory = Object.entries(getValues()).reduce<InventoryForm>((acc, [id, value]) => {
-      const count = parseInt(value);
-      const stock = piecesState.get(id)?.inStockCount;
-      count && stock && (acc[id] = `${count + stock}`);
+      const count = parseInt(value) ?? 0;
+      const stock = piecesState.get(id)?.inStockCount ?? 0;
+      acc[id] = `${count + stock}`;
       return acc;
     }, {});
     store.equipmentsRequirementStore.updateInventory(inventory);
+    reset();
   };
 
   const isFullScreen = useMediaQuery(theme.breakpoints.down('md'));
   const isXsOrSmallerScreen = useMediaQuery(theme.breakpoints.down('sm'));
   const hasManyPieces = () => pieces.length > 3;
 
-  return <Dialog open={open} keepMounted fullWidth
+  return !onceOpen ? null : <Dialog open={open} keepMounted fullWidth
     fullScreen={hasManyPieces() && isFullScreen}
     maxWidth={hasManyPieces() && 'xl'}>
     <DialogTitle>獲得した設計図</DialogTitle>

--- a/components/calculationInput/equipments/inventory/AddToInventoryDialog.tsx
+++ b/components/calculationInput/equipments/inventory/AddToInventoryDialog.tsx
@@ -1,13 +1,9 @@
 import styles from './AddToInventoryDialog.module.scss';
 import {
-  Box,
-  Button, Dialog, DialogActions, DialogContent, DialogTitle,
-  Stack,
-  ToggleButton,
-  ToggleButtonGroup,
-  useMediaQuery, useTheme,
+  Box, Button, Dialog, DialogActions, DialogContent, DialogTitle,
+  Stack, ToggleButton, ToggleButtonGroup, useMediaQuery, useTheme,
 } from '@mui/material';
-import React, {useEffect, useMemo, useReducer, useState} from 'react';
+import React, {Reducer, useContext, useEffect, useMemo, useReducer, useState} from 'react';
 import {useTranslation} from 'next-i18next';
 import {useForm} from 'react-hook-form';
 import {
@@ -21,7 +17,63 @@ import {
   Comparators, SortingOrder,
   buildArrayIndexComparator, buildComparator,
 } from 'common/sortUtils';
-import {EquipmentCategories} from 'model/Equipment';
+import {EquipmentCategories, EquipmentCompositionType} from 'model/Equipment';
+import {randomId} from 'common/randomId';
+
+const AddToInventoryDialogContext = React.createContext({
+  open: (drops: DropPieceIdWithProbAndCount[]) => {},
+  close: () => {},
+});
+
+export const useAddToInventoryDialogContext = () => {
+  const {open, close} = useContext(AddToInventoryDialogContext);
+  return [open, close] as const;
+};
+
+export const AddToInventoryDialogContextProvider = ({
+  equipById,
+  piecesState,
+  children,
+}: {
+  equipById: EquipmentsById,
+  piecesState: Map<string, PieceState>,
+  children?: React.ReactNode,
+}) => {
+  const [{open, drops}, dispatch] = useReducer<Reducer<{
+    open: boolean;
+    key: string,
+    drops: DropPieceIdWithProbAndCount[],
+  }, {
+    action: 'open',
+    drops: DropPieceIdWithProbAndCount[],
+  } | {
+    action: 'close'
+  }>>((state, action) => (
+    action.action === 'open' ? {
+      open: true,
+      drops: action.drops,
+      key: randomId(),
+    } : {
+      ...state,
+      open: false,
+    }
+  ), {
+    open: false,
+    key: '',
+    drops: [],
+  });
+  const contextValue = useMemo(() => ({
+    open: (drops: DropPieceIdWithProbAndCount[]) => dispatch({action: 'open', drops}),
+    close: () => dispatch({action: 'close'}),
+  }), [dispatch]);
+
+  return <AddToInventoryDialogContext.Provider value={contextValue}>
+    <AddToInventoryDialog open={open}
+      onUpdate={contextValue.close} onCancel={contextValue.close}
+      equipById={equipById} piecesState={piecesState} drops={drops} />
+    {children}
+  </AddToInventoryDialogContext.Provider>;
+};
 
 const AddToInventoryDialog = ({
   open,
@@ -42,12 +94,6 @@ const AddToInventoryDialog = ({
   const {t} = useTranslation('home');
   const theme = useTheme();
 
-  // hack to lazy rendering
-  const [onceOpen, notifyOpened] = useReducer((x) => true, false);
-  useEffect(() => {
-    open && notifyOpened();
-  }, [open]);
-
   const [mode, setMode] = useState<'all' | 'lack' | 'required'>('lack');
 
   const pieces = useMemo(() => {
@@ -55,13 +101,15 @@ const AddToInventoryDialog = ({
     // 20-4: Watch, Charm, Badge
     // 13-1: Shoes, Gloves, Hat
     // descending tier -> descending category order?
-    return drops.map(({id}) => (piecesState.get(id) ?? {
+    return drops.filter(({id}) => (
+      equipById.get(id)?.equipmentCompositionType === EquipmentCompositionType.Piece
+    )).map(({id}) => (piecesState.get(id) ?? {
       pieceId: id,
       needCount: 0,
-      inStockCount: 0,
+      inStockCount: store.equipmentsRequirementStore.piecesInventory.get(id)?.inStockCount ?? 0,
     })).filter((state) => ({
       all: true,
-      lack: state.needCount < state.inStockCount,
+      lack: state.needCount > state.inStockCount,
       required: state.needCount > 0,
     }[mode])).sort(buildComparator(
         (piece) => equipById.get(piece.pieceId),
@@ -71,46 +119,51 @@ const AddToInventoryDialog = ({
             SortingOrder.Descending
         )),
     ));
-  }, [drops, piecesState, mode, equipById]);
-  const defaultValues = useMemo(() => {
-    return pieces.reduce<InventoryForm>((acc, piece) => {
-      acc[piece.pieceId] = '';
-      return acc;
-    }, {});
-  }, [pieces]);
+  }, [drops, equipById, piecesState, store.equipmentsRequirementStore.piecesInventory, mode]);
 
   const {
-    control,
-    formState: {isValid: isCountValid, errors: allErrors},
-    getValues,
-    reset,
+    control, formState,
+    getValues, reset,
+    getFieldState, setFocus,
+    handleSubmit,
   } = useForm<InventoryForm>({
     mode: 'onChange',
-    defaultValues,
+    defaultValues: Object.fromEntries(drops.map(({id}) => [id, ''])),
   });
 
-  const handleCancelDialog = () => {
+  useEffect(() => {
+    if (!open) return;
+    reset(Object.fromEntries(drops.map(({id}) => [id, ''])));
+  }, [drops, open, reset]);
+
+  const handleCancel = () => {
     onCancel();
-    reset();
   };
 
-  const handleUpdateInventory = () => {
-    onUpdate(getValues());
-    const inventory = Object.entries(getValues()).reduce<InventoryForm>((acc, [id, value]) => {
-      const count = parseInt(value) ?? 0;
-      const stock = piecesState.get(id)?.inStockCount ?? 0;
-      acc[id] = `${count + stock}`;
-      return acc;
-    }, {});
-    store.equipmentsRequirementStore.updateInventory(inventory);
-    reset();
-  };
+  const handleUpdate = handleSubmit((values) => {
+    onUpdate(values);
+    store.equipmentsRequirementStore.addPiecesToInventory(values);
+  }, (errors) => {
+    const field = Object.entries(errors).find(([, it]) => it && 'ref' in it)?.[0];
+    console.log(errors);
+    field && setFocus(field);
+  });
 
   const isFullScreen = useMediaQuery(theme.breakpoints.down('md'));
   const isXsOrSmallerScreen = useMediaQuery(theme.breakpoints.down('sm'));
   const hasManyPieces = () => pieces.length > 3;
 
-  return !onceOpen ? null : <Dialog open={open} keepMounted fullWidth
+  useEffect(() => {
+    const id = setTimeout(() => {
+      const field = pieces.find(({pieceId}) => (
+        getValues(pieceId) === '' || getFieldState(pieceId).invalid
+      )) ?? pieces[0];
+      field && setFocus(field.pieceId, {shouldSelect: true});
+    }, 100);
+    return () => clearTimeout(id);
+  }, [equipById, getFieldState, getValues, open, pieces, setFocus]);
+
+  return <Dialog open={open} fullWidth
     fullScreen={hasManyPieces() && isFullScreen}
     maxWidth={hasManyPieces() && 'xl'}>
     <Stack component={DialogTitle} direction='row' alignItems='center'>
@@ -127,12 +180,11 @@ const AddToInventoryDialog = ({
     <DialogContent className={styles.dialogContentContainer}>
       <div className={styles.filler}></div>
       <div className={`${styles.container} ${isXsOrSmallerScreen && styles.xs}`}>
-        {pieces.map((piece, index) => {
-          return <ObtainedPieceBox key={piece.pieceId} allErrors={allErrors}
-            control={control}
-            equipmentsById={equipById}
-            piece={piece}
-            focused={index === 0}/>;
+        {pieces.map((piece) => {
+          return <ObtainedPieceBox key={piece.pieceId}
+            allErrors={formState.errors} control={control}
+            equipmentsById={equipById} piece={piece}
+            required={false} />;
         })}
       </div>
       {pieces.length === 0 && <div>{t('filterResultEmpty')}</div>}
@@ -140,8 +192,8 @@ const AddToInventoryDialog = ({
     </DialogContent>
 
     <DialogActions>
-      <Button onClick={handleCancelDialog}>{t('cancelButton')}</Button>
-      <Button onClick={handleUpdateInventory} disabled={!isCountValid}>{t('addButton')}</Button>
+      <Button onClick={handleCancel}>{t('cancelButton')}</Button>
+      <Button onClick={handleUpdate} disabled={!formState.isValid}>{t('addButton')}</Button>
     </DialogActions>
   </Dialog>;
 };

--- a/components/calculationInput/equipments/inventory/ObtainedPieceBox.module.scss
+++ b/components/calculationInput/equipments/inventory/ObtainedPieceBox.module.scss
@@ -1,0 +1,11 @@
+@use 'components/calculationInput/common/common-calculation-input-layout';
+
+.equipmentInputContainer{
+  display: flex;
+  margin: 10px;
+  align-items: center;
+}
+
+.equipmentCard{
+  @include common-calculation-input-layout.items-list;
+}

--- a/components/calculationInput/equipments/inventory/ObtainedPieceBox.tsx
+++ b/components/calculationInput/equipments/inventory/ObtainedPieceBox.tsx
@@ -8,7 +8,8 @@ import React from 'react';
 import {EquipmentsById} from 'components/calculationInput/PiecesCalculationCommonTypes';
 import {PieceState} from 'components/calculationInput/equipments/inventory/PiecesInventory';
 import {Control} from 'react-hook-form/dist/types/form';
-import {InventoryForm} from 'components/calculationInput/equipments/inventory/InventoryUpdateDialog';
+import {InventoryForm}
+  from 'components/calculationInput/equipments/inventory/InventoryUpdateDialog';
 import {useTranslation} from 'next-i18next';
 
 const ObtainedPieceBox = function({
@@ -16,11 +17,13 @@ const ObtainedPieceBox = function({
   piece,
   control,
   allErrors,
+  focused,
 }: {
   equipmentsById: EquipmentsById,
   piece: PieceState,
   control: Control<InventoryForm>,
   allErrors: any,
+  focused?: boolean,
 }) {
   const {t} = useTranslation('home');
 
@@ -38,7 +41,7 @@ const ObtainedPieceBox = function({
     </Card>
     <Box sx={{mr: 2}}/>
     <PositiveIntegerOnlyInput name={piece.pieceId}
-      min={0}
+      min={0} focused={focused}
       control={control} showError={!!allErrors[piece.pieceId]}
       helperText={allErrors[piece.pieceId]?.message ?? ''}
       inputLabel={t('addPieceDialog.obtainedCount')} />

--- a/components/calculationInput/equipments/inventory/ObtainedPieceBox.tsx
+++ b/components/calculationInput/equipments/inventory/ObtainedPieceBox.tsx
@@ -1,0 +1,48 @@
+import styles from './PieceUpdateBox.module.scss';
+import {Card, CardActionArea} from '@mui/material';
+import EquipmentCard from 'components/bui/card/EquipmentCard';
+import BuiBanner from 'components/bui/BuiBanner';
+import Box from '@mui/material/Box';
+import PositiveIntegerOnlyInput from 'components/calculationInput/common/PositiveIntegerOnlyInput';
+import React from 'react';
+import {EquipmentsById} from 'components/calculationInput/PiecesCalculationCommonTypes';
+import {PieceState} from 'components/calculationInput/equipments/inventory/PiecesInventory';
+import {Control} from 'react-hook-form/dist/types/form';
+import {InventoryForm} from 'components/calculationInput/equipments/inventory/InventoryUpdateDialog';
+import {useTranslation} from 'next-i18next';
+
+const ObtainedPieceBox = function({
+  equipmentsById,
+  piece,
+  control,
+  allErrors,
+}: {
+  equipmentsById: EquipmentsById,
+  piece: PieceState,
+  control: Control<InventoryForm>,
+  allErrors: any,
+}) {
+  const {t} = useTranslation('home');
+
+  const pieceIcon = equipmentsById.get(piece.pieceId)?.icon;
+  if (!pieceIcon) return null;
+
+  return <div className={styles.equipmentInputContainer}>
+    <Card elevation={1}>
+      <CardActionArea disabled>
+        <div className={styles.equipmentCard}>
+          <EquipmentCard imageName={pieceIcon} bottomRightText={`x${piece.inStockCount}`} />
+          <BuiBanner label={`${piece.needCount}`} width={'120%'} />
+        </div>
+      </CardActionArea>
+    </Card>
+    <Box sx={{mr: 2}}/>
+    <PositiveIntegerOnlyInput name={piece.pieceId}
+      min={0}
+      control={control} showError={!!allErrors[piece.pieceId]}
+      helperText={allErrors[piece.pieceId]?.message ?? ''}
+      inputLabel={t('addPieceDialog.obtainedCount')} />
+  </div>;
+};
+
+export default ObtainedPieceBox;

--- a/components/calculationInput/equipments/inventory/ObtainedPieceBox.tsx
+++ b/components/calculationInput/equipments/inventory/ObtainedPieceBox.tsx
@@ -12,19 +12,23 @@ import {InventoryForm}
   from 'components/calculationInput/equipments/inventory/InventoryUpdateDialog';
 import {useTranslation} from 'next-i18next';
 
+interface ObtainedPieceBoxProps
+  extends Omit<React.ComponentProps<typeof PositiveIntegerOnlyInput>,
+    'control' | 'name' | 'showError' | 'helperText' | 'inputLabel'>
+{
+  equipmentsById: EquipmentsById,
+  piece: PieceState,
+  control: Control<InventoryForm>,
+  allErrors: any,
+}
+
 const ObtainedPieceBox = function({
   equipmentsById,
   piece,
   control,
   allErrors,
-  focused,
-}: {
-  equipmentsById: EquipmentsById,
-  piece: PieceState,
-  control: Control<InventoryForm>,
-  allErrors: any,
-  focused?: boolean,
-}) {
+  ...others
+}: ObtainedPieceBoxProps) {
   const {t} = useTranslation('home');
 
   const pieceIcon = equipmentsById.get(piece.pieceId)?.icon;
@@ -40,8 +44,8 @@ const ObtainedPieceBox = function({
       </CardActionArea>
     </Card>
     <Box sx={{mr: 2}}/>
-    <PositiveIntegerOnlyInput name={piece.pieceId}
-      min={0} focused={focused}
+    <PositiveIntegerOnlyInput {...others} name={piece.pieceId}
+      min={0}
       control={control} showError={!!allErrors[piece.pieceId]}
       helperText={allErrors[piece.pieceId]?.message ?? ''}
       inputLabel={t('addPieceDialog.obtainedCount')} />

--- a/components/calculationInput/listStagesResult/AllPotentialStages.tsx
+++ b/components/calculationInput/listStagesResult/AllPotentialStages.tsx
@@ -36,7 +36,8 @@ const AllPotentialStages = ({
             campaignInfo={campaign} stageExplanationLabel={t('resultPiecesCountOnStage', {count: campaign?.targetRewardIds?.size})}
             allDrops={allDrops} equipmentsById={equipmentsById}
             shouldHighLightPiece={(id) => campaign.targetRewardIds.has(id)}
-            hidePieceDropCount/>
+            hidePieceDropCount
+            piecesState={piecesState} />
         </Box>;
       })
     }

--- a/components/calculationResult/CampaignDropItemsList.module.scss
+++ b/components/calculationResult/CampaignDropItemsList.module.scss
@@ -14,8 +14,9 @@
   color: #2d4665;
 }
 
-.campaignNameAndTimes{
+.campaignHeader {
   align-items: center;
+  margin-bottom: 1rem;
 }
 
 .noSelection{

--- a/components/calculationResult/CampaignDropItemsList.tsx
+++ b/components/calculationResult/CampaignDropItemsList.tsx
@@ -1,12 +1,15 @@
 import styles from './CampaignDropItemsList.module.scss';
 import {Card, CardContent, Typography} from '@mui/material';
-import React, {FunctionComponent} from 'react';
+import React, {FunctionComponent, useState} from 'react';
 import {Campaign} from 'model/Campaign';
 import {DropPieceIdWithProbAndCount, EquipmentsById} from 'components/calculationInput/PiecesCalculationCommonTypes';
 import Grid from '@mui/material/Unstable_Grid2';
 import BuiBanner from '../bui/BuiBanner';
 import {useTranslation} from 'next-i18next';
 import EquipmentCard from 'components/bui/card/EquipmentCard';
+import BuiButton from 'components/bui/BuiButton';
+import AddToInventoryDialog from '../calculationInput/equipments/inventory/AddToInventoryDialog';
+import {PieceState} from 'components/calculationInput/equipments/inventory/PiecesInventory';
 
 type CampaignDropItemsListProps = {
     campaignInfo: Campaign,
@@ -16,6 +19,7 @@ type CampaignDropItemsListProps = {
     hidePieceDropCount?: boolean,
     containerCardVariation?: 'elevation' | 'outlined',
     shouldHighLightPiece?: (pieceId: string) => boolean,
+    piecesState: Map<string, PieceState>,
 }
 
 const CampaignDropItemsList :
@@ -27,14 +31,22 @@ const CampaignDropItemsList :
       shouldHighLightPiece,
       hidePieceDropCount= false,
       containerCardVariation = 'elevation',
+      piecesState,
     }
     ) => {
       const {t} = useTranslation('home');
+      const [open, setOpen] = useState(false);
       return <Card variant={containerCardVariation} className={styles.cardWrapper}
         elevation={containerCardVariation == 'elevation' ? 2 : undefined}>
+        <AddToInventoryDialog open={open}
+          onUpdate={() => setOpen(false)}
+          onCancel={() => setOpen(false)}
+          equipById={equipmentsById}
+          piecesState={piecesState}
+          drops={allDrops} />
         <CardContent>
           <Grid container>
-            <Grid xs={12} container className={styles.campaignNameAndTimes}>
+            <Grid xs={12} container className={styles.campaignHeader}>
               <Typography variant={'h4'}>
                 {`${campaignInfo.area}-${campaignInfo.stage}`}
               </Typography>
@@ -43,6 +55,12 @@ const CampaignDropItemsList :
                 sx={{marginLeft: '0.8em'}}
                 backgroundColor={'secondary'}
                 width={'unset'}/>
+
+              <div style={{flexGrow: 1}}/>
+
+              <BuiButton color={'baButtonSecondary'} onClick={() => setOpen(true)}>
+                {'結果を記入'}
+              </BuiButton>
             </Grid>
 
             <Grid xs={12} className={styles.noSelection}>

--- a/components/calculationResult/CampaignDropItemsList.tsx
+++ b/components/calculationResult/CampaignDropItemsList.tsx
@@ -1,14 +1,17 @@
 import styles from './CampaignDropItemsList.module.scss';
 import {Card, CardContent, Typography} from '@mui/material';
-import React, {FunctionComponent, useState} from 'react';
+import React, {FunctionComponent} from 'react';
 import {Campaign} from 'model/Campaign';
-import {DropPieceIdWithProbAndCount, EquipmentsById} from 'components/calculationInput/PiecesCalculationCommonTypes';
+import {
+  DropPieceIdWithProbAndCount, EquipmentsById,
+} from 'components/calculationInput/PiecesCalculationCommonTypes';
 import Grid from '@mui/material/Unstable_Grid2';
 import BuiBanner from '../bui/BuiBanner';
 import {useTranslation} from 'next-i18next';
 import EquipmentCard from 'components/bui/card/EquipmentCard';
 import BuiButton from 'components/bui/BuiButton';
-import AddToInventoryDialog from '../calculationInput/equipments/inventory/AddToInventoryDialog';
+import {useAddToInventoryDialogContext}
+  from '../calculationInput/equipments/inventory/AddToInventoryDialog';
 import {PieceState} from 'components/calculationInput/equipments/inventory/PiecesInventory';
 
 type CampaignDropItemsListProps = {
@@ -35,15 +38,10 @@ const CampaignDropItemsList :
     }
     ) => {
       const {t} = useTranslation('home');
-      const [open, setOpen] = useState(false);
+
+      const [openDialog] = useAddToInventoryDialogContext();
       return <Card variant={containerCardVariation} className={styles.cardWrapper}
         elevation={containerCardVariation == 'elevation' ? 2 : undefined}>
-        <AddToInventoryDialog open={open}
-          onUpdate={() => setOpen(false)}
-          onCancel={() => setOpen(false)}
-          equipById={equipmentsById}
-          piecesState={piecesState}
-          drops={allDrops} />
         <CardContent>
           <Grid container>
             <Grid xs={12} container className={styles.campaignHeader}>
@@ -58,8 +56,8 @@ const CampaignDropItemsList :
 
               <div style={{flexGrow: 1}}/>
 
-              <BuiButton color={'baButtonSecondary'} onClick={() => setOpen(true)}>
-                {'結果を記入'}
+              <BuiButton color={'baButtonSecondary'} onClick={() => openDialog(allDrops)}>
+                {t('fillRewards')}
               </BuiButton>
             </Grid>
 
@@ -85,4 +83,4 @@ const CampaignDropItemsList :
       </Card>;
     };
 
-export default CampaignDropItemsList;
+export default React.memo(CampaignDropItemsList);

--- a/components/calculationResult/IgnoredCampaigns.tsx
+++ b/components/calculationResult/IgnoredCampaigns.tsx
@@ -14,6 +14,7 @@ import Box from '@mui/material/Box';
 import {useTranslation} from 'next-i18next';
 import {getRewardsByRegion} from 'common/gameDataHandlerUtil';
 import {GameServer} from 'model/Equipment';
+import {PieceState} from 'components/calculationInput/equipments/inventory/PiecesInventory';
 
 type CampaignByRequiredPieceCount = {
     [key: number]: Campaign[],
@@ -79,7 +80,11 @@ const IgnoredCampaigns = ({
   allRequiredPieceIds,
   equipmentsById,
   gameServer,
-}: IgnoredCampaignsProps & {equipmentsById: EquipmentsById}) => {
+  piecesState,
+}: IgnoredCampaignsProps & {
+  equipmentsById: EquipmentsById,
+  piecesState: Map<string, PieceState>,
+}) => {
   const {t} = useTranslation('home');
 
   const skippedValidCampaigns = useMemo(
@@ -123,7 +128,8 @@ const IgnoredCampaigns = ({
               campaignInfo={campaign} stageExplanationLabel={t('stageIsSkipped')}
               allDrops={allDrops} equipmentsById={equipmentsById}
               containerCardVariation={'outlined'}
-              hidePieceDropCount/>
+              hidePieceDropCount
+              piecesState={piecesState}/>
           </div>;
         })
       }

--- a/components/calculationResult/RecommendedCampaigns.tsx
+++ b/components/calculationResult/RecommendedCampaigns.tsx
@@ -19,6 +19,7 @@ import InefficientRequirementWarning, {
   OnCloseInefficacyDialog,
 } from 'components/calculationInput/common/InefficientRequirementWarning';
 import {getRewardsByRegion} from 'common/gameDataHandlerUtil';
+import {PieceState} from 'components/calculationInput/equipments/inventory/PiecesInventory';
 
 
 const RecommendedCampaigns = ({
@@ -28,6 +29,7 @@ const RecommendedCampaigns = ({
   equipmentsRequirementStore,
   normalMissionItemDropRatio,
   onCloseInEfficacyDialog,
+  piecesState,
 }: {
     solution: Solution<string>,
     campaignsById: CampaignsById,
@@ -35,6 +37,7 @@ const RecommendedCampaigns = ({
     equipmentsRequirementStore: IEquipmentsRequirementStore,
     normalMissionItemDropRatio: number,
     onCloseInEfficacyDialog: OnCloseInefficacyDialog,
+    piecesState: Map<string, PieceState>,
 }) => {
   const {t} = useTranslation('home');
   const store = useStore();
@@ -94,7 +97,7 @@ const RecommendedCampaigns = ({
             return <div key={key} className={styles.selectedPiecesCard}>
               <CampaignDropItemsList
                 campaignInfo={campaignInfo} stageExplanationLabel={t('stageSweepingTimes', {sweepingTimes})}
-                allDrops={allDrops} equipmentsById={equipmentsById} />
+                allDrops={allDrops} equipmentsById={equipmentsById} piecesState={piecesState} />
             </div>;
           })
     }

--- a/model/Equipment.ts
+++ b/model/Equipment.ts
@@ -9,9 +9,16 @@ export enum GameServer {
     China = 'China',
 }
 
+export const EquipmentCategories = [
+  'Hat', 'Gloves', 'Shoes',
+  'Bag', 'Badge', 'Hairpin',
+  'Charm', 'Watch', 'Necklace',
+] as const;
+export type EquipmentCategory = typeof EquipmentCategories[number];
+
 export interface Equipment {
     id: string
-    category: string
+    category: EquipmentCategory
     tier: number
     icon: string
     jpName: string

--- a/public/locales/en/home.json
+++ b/public/locales/en/home.json
@@ -76,6 +76,7 @@
   },
   "stageSweepingTimes": "{{sweepingTimes}} times",
   "stageIsSkipped": "Skipped",
+  "fillRewards": "Fill in the Rewards",
   "possibleRewards": "Possible Rewards",
   "otherStages": "Other stages",
   "otherStagesSkippedReason": "Skipped because of inefficiency",

--- a/public/locales/en/home.json
+++ b/public/locales/en/home.json
@@ -21,7 +21,9 @@
     "minimumIs": "Minimum is {{min}}",
     "maximumIs": "Maximum is {{max}}",
     "quantity": "Quantity",
-    "inStockCount": "In Stock Number"
+    "inStockCount": "In Stock Number",
+    "addToInventory": "Acquired Pieces",
+    "obtainedCount": "Acquisitions"
   },
   "selectInputMode": "Select input mode",
   "selectResultMode": "Output Mode",
@@ -45,6 +47,14 @@
     "maxLengthIs": "Maximum characters are {{max}}",
     "enterNickName":  "Enter a nickname(optional)",
     "enterNickNameNormalHelperText": "Enter a student name to help you memorize equipment ownership"
+  },
+  "filterResultEmpty": "Could not find any equipment matching the filter.",
+  "piecesFilter": {
+    "filter": {
+      "required": "Required",
+      "insufficient": "Insufficient",
+      "all": "All"
+    }
   },
   "thinsToNote": {
     "title": "Things to note",

--- a/public/locales/ja/home.json
+++ b/public/locales/ja/home.json
@@ -21,7 +21,8 @@
     "minimumIs": "最小値は{{min}}です",
     "maximumIs": "最大値は{{max}}です",
     "quantity": "欲しい数",
-    "inStockCount": "所持数"
+    "inStockCount": "所持数",
+    "obtainedCount": "獲得数"
   },
   "selectInputMode": "入力モード",
   "selectResultMode": "結果表示モード",

--- a/public/locales/ja/home.json
+++ b/public/locales/ja/home.json
@@ -75,6 +75,7 @@
   },
   "stageSweepingTimes": "{{sweepingTimes}}回",
   "stageIsSkipped": "スキップ",
+  "fillRewards": "結果を記入",
   "possibleRewards": "獲得可能報酬",
   "otherStages": "他の任務",
   "otherStagesSkippedReason": "非効率のためスキップしました",

--- a/public/locales/ja/home.json
+++ b/public/locales/ja/home.json
@@ -22,6 +22,7 @@
     "maximumIs": "最大値は{{max}}です",
     "quantity": "欲しい数",
     "inStockCount": "所持数",
+    "addToInventory": "獲得した設計図",
     "obtainedCount": "獲得数"
   },
   "selectInputMode": "入力モード",
@@ -45,6 +46,14 @@
     "maxLengthIs": "{{max}}文字以内",
     "enterNickName":  "ニックネーム入力（任意）",
     "enterNickNameNormalHelperText": "生徒の名前をメモとして入力すれば、装備の管理ができます"
+  },
+  "filterResultEmpty": "条件に合う装備が見つかりません。",
+  "piecesFilter": {
+    "filter": {
+      "required": "必要",
+      "insufficient": "不足",
+      "all": "すべて"
+    }
   },
   "thinsToNote": {
     "title": "注記",

--- a/public/locales/zh/home.json
+++ b/public/locales/zh/home.json
@@ -75,6 +75,7 @@
   },
   "stageSweepingTimes": "{{sweepingTimes}}次",
   "stageIsSkipped": "跳过",
+  "fillRewards": "填写结果",
   "possibleRewards": "可获得奖励",
   "otherStages": "其他关卡",
   "otherStagesSkippedReason": "因刷图效率不高而跳过",

--- a/public/locales/zh/home.json
+++ b/public/locales/zh/home.json
@@ -21,7 +21,9 @@
     "minimumIs": "不能小于{{min}}",
     "maximumIs": "不能大于{{max}}",
     "quantity": "数量",
-    "inStockCount": "库存数量"
+    "inStockCount": "库存数量",
+    "addToInventory": "获得设计图",
+    "obtainedCount": "收购数量"
   },
   "selectInputMode": "输入模式",
   "selectResultMode": "结果展示模式",
@@ -44,6 +46,14 @@
     "maxLengthIs": "最多输入{{max}}个字",
     "enterNickName":  "添加昵称（选填）",
     "enterNickNameNormalHelperText": "可以输入学生姓名方便记和进行装备管理"
+  },
+  "filterResultEmpty": "我找不到符合要求的设备。",
+  "piecesFilter": {
+    "filter": {
+      "required": "所需",
+      "insufficient": "不足",
+      "all": "全部"
+    }
   },
   "thinsToNote": {
     "title": "注意事项",

--- a/stores/EquipmentsRequirementStore.ts
+++ b/stores/EquipmentsRequirementStore.ts
@@ -134,20 +134,25 @@ export const EquipmentsRequirementStore = types
         for (const [pieceId, inStockCountStr] of Object.entries(inventoryForm)) {
           const inStockCount = parseInt(inStockCountStr) ?? 0;
           if (inStockCount !== 0) {
-            self.piecesInventory.put( {
-              pieceId,
-              inStockCount: parseInt(inStockCountStr) ?? 0,
-            });
+            self.piecesInventory.put({pieceId, inStockCount});
           } else {
             self.piecesInventory.delete(pieceId);
           }
         }
       };
 
+      const addPiecesToInventory = (pieces: InventoryForm) => {
+        updateInventory(Object.fromEntries(Object.entries(pieces).map(([id, value]) => {
+          const count = parseInt(value) || 0;
+          const stock = self.piecesInventory.get(id)?.inStockCount || 0;
+          return [id, `${count + stock}`];
+        })));
+      };
+
       return {addPiecesRequirement, updatePiecesRequirement, deletePiecesRequirement,
         addEquipmentsRequirement, updateEquipmentsRequirement, deleteEquipmentsRequirement,
         getAllRequiredPieceIds, updateRequirementMode, updateInventory,
-        updateResultMode,
+        updateResultMode, addPiecesToInventory,
       };
     });
 


### PR DESCRIPTION
Added `Enter Results` button to the `CampaignDropItemList` card.
This button opens a dialog similar to the `InventoryUpdateDialog`, and filling out the items obtained to this dialog will add them to stock counts in the inventory.