### PR TITLE
Adjust layout of equipment cards

### DIFF
--- a/components/bui/card/EquipmentCard.module.scss
+++ b/components/bui/card/EquipmentCard.module.scss
@@ -7,19 +7,18 @@ $leftBottomBadgeColor: rgb(62, 134, 184);
 .bottomRightText{
   position: absolute;
   text-shadow: #fff 1px 0 0, #fff 0 1px 0, #fff -1px 0 0, #fff 0 -1px 0;
-  font-style: italic;
   color: black;
   bottom: 3px;
-  right: 10px;
+  right: 3px;
 }
 
 .bottomLeftText{
   position: absolute;
   bottom: 3px;
-  left: 5px;
-  padding: 1.5px;
-  border-radius: 35%;
-  line-height: 1.1;
+  left: 3px;
+  padding: 1.5px 2px;
+  border-radius: 6px;
+  line-height: 1;
   border: 1px solid $leftBottomBadgeColor;
   background-color: white;
   color: $leftBottomBadgeColor;

--- a/components/bui/card/EquipmentCard.tsx
+++ b/components/bui/card/EquipmentCard.tsx
@@ -4,32 +4,21 @@ import EquipmentImage from 'components/bui/card/EquipmentImage';
 import BuiCard from 'components/bui/BuiCard';
 import {CardActionArea} from '@mui/material';
 
+const EquipmentCard = ({
+  imageName, bottomLeftText, bottomRightText,
+  onClick, isSelected = false, hasOuterMargin = false,
+}: {
+  imageName: string, bottomLeftText?:string, bottomRightText?:string,
+  onClick?: MouseEventHandler, isSelected?: boolean, hasOuterMargin?: boolean,
+}) => {
+  return <BuiCard onClick={onClick}
+    className={`${hasOuterMargin ? styles.outerMargin : ''} ${isSelected ? 'wiz-selected' : ''}`}>
 
-const EquipmentCard = ({imageName, bottomLeftText, bottomRightText, onClick,
-  isSelected = false,
-  hasOuterMargin = false}:
-                           {imageName: string,
-                             onClick?: MouseEventHandler,
-                             bottomLeftText?:string,
-                             bottomRightText?:string,
-                             isSelected?: boolean,
-                             hasOuterMargin?: boolean}) => {
-  const equipmentContent = <React.Fragment>
-    <EquipmentImage imageName={imageName} />
-    {bottomLeftText ? <div className={styles.bottomLeftText}>{bottomLeftText}</div> :
-        null}
-    {bottomRightText ? <div className={styles.bottomRightText}>{bottomRightText}</div> :
-          null}</React.Fragment>;
-
-  return <BuiCard className={`${hasOuterMargin ? styles.outerMargin : ''} ${isSelected ? 'wiz-selected' : ''}`}>
-    {
-      onClick ?
-          <CardActionArea onClick={onClick} className={'exclude-revert-transform'}>
-            <div className={'revert-wiz-transform'}>
-              {equipmentContent}
-            </div>
-          </CardActionArea>:equipmentContent
-    }
+    <CardActionArea disabled={!onClick} className='exclude-revert-transform'>
+      <div className='revert-wiz-transform'><EquipmentImage imageName={imageName}/></div>
+      {bottomLeftText && <div className={styles.bottomLeftText}>{bottomLeftText}</div>}
+      {bottomRightText && <div className={styles.bottomRightText}>{bottomRightText}</div>}
+    </CardActionArea>
   </BuiCard>;
 };
 

--- a/components/bui/card/EquipmentCard.tsx
+++ b/components/bui/card/EquipmentCard.tsx
@@ -2,7 +2,7 @@ import styles from 'components/bui/card/EquipmentCard.module.scss';
 import React, {MouseEventHandler} from 'react';
 import EquipmentImage from 'components/bui/card/EquipmentImage';
 import BuiCard from 'components/bui/BuiCard';
-import {CardActionArea} from '@mui/material';
+import {Box, CardActionArea} from '@mui/material';
 
 const EquipmentCard = ({
   imageName, bottomLeftText, bottomRightText,
@@ -14,11 +14,11 @@ const EquipmentCard = ({
   return <BuiCard onClick={onClick}
     className={`${hasOuterMargin ? styles.outerMargin : ''} ${isSelected ? 'wiz-selected' : ''}`}>
 
-    <CardActionArea disabled={!onClick} className='exclude-revert-transform'>
+    <Box component={onClick ? CardActionArea : 'div'} className='exclude-revert-transform'>
       <div className='revert-wiz-transform'><EquipmentImage imageName={imageName}/></div>
       {bottomLeftText && <div className={styles.bottomLeftText}>{bottomLeftText}</div>}
       {bottomRightText && <div className={styles.bottomRightText}>{bottomRightText}</div>}
-    </CardActionArea>
+    </Box>
   </BuiCard>;
 };
 


### PR DESCRIPTION
<div><img src="https://github.com/edwardez/sensei-helper/assets/50271984/f79b4af5-9bcb-44dc-8a08-dedd5fa2df3d" width=500></div>
↓
<div><img src="https://github.com/edwardez/sensei-helper/assets/50271984/fa0690b4-55f1-43e4-958c-bd9ad160574d" width=500></div>

- bottom right text (stock text):
  - use skew transform instead of italic.
  - the right space has narrowed.
- bottom left text (tier text):
  - also skewed.
  - border rect is smaller.

Replaced Italic with skew and truncated the size of tier label to get closer to the in game look. Now that it is more compact, it can also show both tier and stock count on the card.

<div><img src="https://github.com/edwardez/sensei-helper/assets/50271984/5795ab27-af44-4f30-b364-12a4cad6dd68" width=100></div>
