### PR TITLE
Add dialog for data management

### DIFF
--- a/components/appBar/WizAppBar.tsx
+++ b/components/appBar/WizAppBar.tsx
@@ -14,9 +14,14 @@ import Link from 'next/link';
 import SettingsDialog from 'components/settings/SettingsDialog';
 import {useTranslation} from 'next-i18next';
 import {Locale} from 'common/locales';
+import {DataManagementDialog} from 'components/settings/dataManagement/DataManagementDialog';
+import {useStore} from 'stores/WizStore';
+import {applySnapshot} from 'mobx-state-tree';
 
+// eslint-disable-next-line require-jsdoc
 export default function WizAppBar() {
   const {t} = useTranslation('home');
+  const store = useStore();
   const trigger = useScrollTrigger({
     disableHysteresis: true,
     threshold: 0,
@@ -24,6 +29,7 @@ export default function WizAppBar() {
 
   const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null);
   const [isSettingsOpened, setIsSettingsOpened] = React.useState<boolean>(false);
+  const [isDataManagementOpened, setDataManagementOpened] = React.useState<string | false>(false);
 
   const open = Boolean(anchorEl);
   const handleOpenMenu = (event: React.MouseEvent<HTMLButtonElement>) => {
@@ -38,6 +44,10 @@ export default function WizAppBar() {
   };
   const handleCloseSettingsDialog = () => {
     setIsSettingsOpened(false);
+  };
+  const handleOpenDataManagementDialog = () => {
+    setDataManagementOpened(crypto.randomUUID());
+    handleCloseMenu();
   };
 
   const navigateToThenCloseMenu = (url:string) => {
@@ -99,6 +109,7 @@ export default function WizAppBar() {
               onClose={handleCloseMenu}>
               <MenuItem onClick={() => navigateToThenCloseMenu('privacy')}>{t('privacy')}</MenuItem>
               <MenuItem onClick={handleOpenSettingsDialog}>{t('settings')}</MenuItem>
+              <MenuItem onClick={handleOpenDataManagementDialog}>データ管理</MenuItem>
               <MenuItem onClick={() => navigateToThenCloseMenu('about')}>{t('about')}</MenuItem>
             </Menu>
           </Box>
@@ -106,6 +117,13 @@ export default function WizAppBar() {
       </AppBar>
       <Toolbar />
       <SettingsDialog open={isSettingsOpened} onCloseDialog={handleCloseSettingsDialog}/>
+      <DataManagementDialog key={isDataManagementOpened || undefined}
+        open={!!isDataManagementOpened}
+        onCancel={() => setDataManagementOpened(false)}
+        onSubmit={(snapshot) => {
+          applySnapshot(store, snapshot);
+          setDataManagementOpened(false);
+        }} />
     </React.Fragment>
   );
 }

--- a/components/appBar/WizAppBar.tsx
+++ b/components/appBar/WizAppBar.tsx
@@ -46,7 +46,7 @@ export default function WizAppBar() {
     setIsSettingsOpened(false);
   };
   const handleOpenDataManagementDialog = () => {
-    setDataManagementOpened(crypto.randomUUID());
+    setDataManagementOpened(`${Math.random()}`);
     handleCloseMenu();
   };
 
@@ -109,7 +109,7 @@ export default function WizAppBar() {
               onClose={handleCloseMenu}>
               <MenuItem onClick={() => navigateToThenCloseMenu('privacy')}>{t('privacy')}</MenuItem>
               <MenuItem onClick={handleOpenSettingsDialog}>{t('settings')}</MenuItem>
-              <MenuItem onClick={handleOpenDataManagementDialog}>データ管理</MenuItem>
+              <MenuItem onClick={handleOpenDataManagementDialog}>{t('dataManagement')}</MenuItem>
               <MenuItem onClick={() => navigateToThenCloseMenu('about')}>{t('about')}</MenuItem>
             </Menu>
           </Box>

--- a/components/settings/dataManagement/DataManagementDialog.tsx
+++ b/components/settings/dataManagement/DataManagementDialog.tsx
@@ -1,0 +1,267 @@
+import React, {
+  ChangeEventHandler, DragEventHandler, MouseEventHandler, ReactNode,
+  useEffect, useId, useRef, useState,
+} from 'react';
+import {
+  Box, Button, ButtonGroup, Dialog, DialogActions, DialogContent, DialogTitle,
+  FormControl, FormHelperText, OutlinedInput, FormLabel,
+  Snackbar, Stack, Tooltip, styled, useTheme, useMediaQuery, Slide,
+} from '@mui/material';
+import {useTranslation} from 'next-i18next';
+import {Controller, useForm} from 'react-hook-form';
+import {IWizStoreSnapshotOut, useStore} from 'stores/WizStore';
+import {getSnapshot, getType, typecheck} from 'mobx-state-tree';
+import {
+  ContentCopy, ContentPasteGo, FileDownload, FileUpload,
+  InfoOutlined,
+} from '@mui/icons-material';
+
+interface DataManagementFormValues {
+  data: string
+}
+
+// YYYY/MM/DD hh:mm:ss
+const formatter = new Intl.DateTimeFormat('ja-JP', {
+  year: 'numeric', month: '2-digit', day: '2-digit',
+  hour: '2-digit', minute: '2-digit', second: '2-digit',
+});
+
+type Result<T, E = unknown> = {success: true, value: T} | {success: false, error: E}
+const catching = <T, >(block: () => T): Result<T> => {
+  try {
+    return {success: true, value: block()};
+  } catch (e: unknown) {
+    return {success: false, error: e};
+  }
+};
+
+interface MSTError extends Error {
+  message: `[mobx-state-tree] ${string}`
+}
+const isMSTError = (error: unknown): error is MSTError => {
+  return error instanceof Error && error.message.startsWith('[mobx-state-tree] ');
+};
+const convertMSTError = (error: MSTError): string => {
+  return error.message
+      .replace('[mobx-state-tree] ', '')
+      .replace(/Error while converting `[^`]*` to `[^`]*`:\n/, 'Failed to convert data:')
+      .replace(/^\s+/gm, '');
+};
+
+export const DataManagementDialog = ({
+  open = false, mode = 'edit', value,
+  onClose, onCancel, onSubmit, onResetData,
+}: {
+  open?: boolean,
+  mode?: 'edit' | 'recovery',
+  value?: IWizStoreSnapshotOut | string,
+  onClose?: () => void,
+  onCancel?: () => void,
+  onResetData?: () => void,
+  onSubmit?: (snapshot: IWizStoreSnapshotOut) => void,
+}) => {
+  const {t} = useTranslation('home');
+  const theme = useTheme();
+  const isFullScreen = useMediaQuery(theme.breakpoints.down('md'));
+
+  const store = useStore();
+  const inputId = useId();
+  const {
+    getValues, setValue, reset, trigger,
+    formState, handleSubmit, control,
+  } = useForm<DataManagementFormValues>({
+    mode: 'all',
+    defaultValues: value ? {
+      data: typeof value === 'object' ? JSON.stringify(value, null, 2) : value,
+    }: {
+      data: JSON.stringify(getSnapshot(store), null, 2),
+    },
+  });
+  useEffect(() => {
+    const id = setTimeout(() => trigger('data'), 0);
+    return () => clearTimeout(id);
+  }, [trigger]);
+
+  type SnackbarContent = {
+    key: string,
+    msg: ReactNode,
+  };
+  const [snackbar, setSnackbar] = useState<SnackbarContent | null>(null);
+  const [isSnackbarOpen, setSnackbarOpen] = useState(false);
+  const showSnackbar = (content: SnackbarContent) => {
+    setSnackbar(content);
+    setSnackbarOpen(true);
+  };
+
+  const handleCopy: MouseEventHandler = async (e) => {
+    await navigator.clipboard.writeText(getValues('data'));
+    showSnackbar({key: 'copied', msg: 'Copied!'});
+  };
+
+  const handlePaste: MouseEventHandler = async (e) => {
+    const value = await navigator.clipboard.readText();
+    setValue('data', value, {shouldValidate: true});
+    showSnackbar({key: 'pasted', msg: 'Pasted!'});
+  };
+
+  const anchor = useRef<HTMLAnchorElement>(null);
+  const handleDownload: MouseEventHandler<HTMLButtonElement> = async (e) => {
+    if (!anchor.current) return;
+
+    const blob = new Blob([
+      getValues('data'),
+    ], {
+      type: 'application/json',
+    });
+
+    const [date, time] = formatter.format(new Date())
+        .replaceAll('/', '')
+        .replaceAll(':', '')
+        .split(' ');
+    const name = `SenseiHelper_${date}_${time}.json`;
+
+    anchor.current.href = window.URL.createObjectURL(blob);
+    anchor.current.download = name;
+    anchor.current.click();
+    showSnackbar({key: 'exported', msg: `Exported to '${name}'`});
+  };
+
+  const handleUpload: ChangeEventHandler<HTMLInputElement> = async (e) => {
+    const file = e.currentTarget.files?.[0];
+    if (!file) return console.warn('file unspecified');
+    setValue('data', await file.text(), {shouldValidate: true});
+    showSnackbar({key: 'exported', msg: `Imported from ${file.name}`});
+  };
+
+  const handleFileDrop: DragEventHandler = async (e) => {
+    const file = Array.from(e.dataTransfer.files).find((it) => it.type === 'application/json');
+    if (!file) return console.warn('file unspecified');
+    e.preventDefault();
+    setValue('data', await file.text(), {shouldValidate: true});
+    showSnackbar({key: 'exported', msg: `Imported from '${file.name}'`});
+  };
+
+  const parseInput = (value: string) => catching<IWizStoreSnapshotOut>(() => {
+    const parsed = catching(() => JSON.parse(value));
+    if (!parsed.success) {
+      throw parsed?.error instanceof SyntaxError ?
+        parsed.error.message :
+        parsed.error;
+    }
+    const checked = catching(() => typecheck(getType(store), parsed.value));
+    if (!checked.success) {
+      throw isMSTError(checked.error) ?
+        convertMSTError(checked.error) :
+        checked.error;
+    }
+    const result = catching(() => getType(store).create(parsed.value));
+    if (!result.success) {
+      throw result.error;
+    }
+    return getSnapshot(result.value);
+  });
+
+  return <Dialog open={open} fullWidth fullScreen={isFullScreen}
+    PaperProps={{sx: {height: '100%'}}} onClose={onClose} onDrop={handleFileDrop}>
+    <Stack component={DialogTitle} direction='row' alignItems='center' gap='0.5rem'>
+      データ管理
+      <Tooltip title='アプリのデータをバックアップしたり、破損したデータを手動で修復できます。'><InfoOutlined /></Tooltip>
+    </Stack>
+    <Stack component={DialogContent} direction='column'>
+      <Stack flex='0 0 auto' direction='row' flexWrap='wrap' gap='1rem'>
+        <ButtonGroup variant='contained' fullWidth sx={{flex: '1 1 max-content'}}>
+          <Button component='label' tabIndex={-1} startIcon={<FileDownload />}>
+            インポート
+            <HiddenInput type='file' accept='application/json' onChange={handleUpload} />
+          </Button>
+          <Button component='label' onClick={handlePaste} sx={{width: 'unset'}}>
+            <ContentPasteGo fontSize='small'/>
+          </Button>
+        </ButtonGroup>
+        <ButtonGroup variant='contained' fullWidth sx={{flex: '1 1 max-content'}}>
+          <Button startIcon={<FileUpload />} onClick={handleDownload}>
+            エクスポート
+            <Box component='a' ref={anchor} display='none' />
+          </Button>
+          <Button onClick={handleCopy} sx={{width: 'unset'}}>
+            <ContentCopy fontSize='small'/>
+          </Button>
+        </ButtonGroup>
+      </Stack>
+      <Controller control={control} name='data'
+        rules={{
+          required: {value: true, message: '必須です'},
+          validate: (value) => {
+            const result = parseInput(value);
+            return result.success || `${result.error}`;
+          },
+        }}
+        render={({field, fieldState}) => (
+          <FormControl fullWidth variant='outlined' error={fieldState.invalid}
+            margin='normal' sx={{flex: '1 1 100%'}}>
+            <Stack direction='row' gap='0.5rem'>
+              <Box component={FormLabel} htmlFor={inputId} flex='1 1 auto'>JSON</Box>
+              <Box component={Button} variant='text' padding='0'
+                disabled={(!formState.isDirty)}
+                onClick={() => reset()}>
+                リセット
+              </Box>
+            </Stack>
+            <OutlinedInput id={inputId} notched={false}
+              sx={{flex: '1', paddingInline: '1rem 0', paddingBlock: '0.1rem'}}
+              inputComponent='textarea'
+              inputProps={{...field, sx: {
+                height: '100%',
+                padding: '0',
+                resize: 'none',
+                fontFamily: `'MyricaM M', Menlo, Monaco, 'Courier New', monospace`,
+                overscrollBehavior: 'contain',
+              }}} />
+            <FormHelperText component={Box} maxWidth='100%' whiteSpace='nowrap'>
+              <Tooltip title={fieldState.error && <PreText>{fieldState.error.message}</PreText>}>
+                {fieldState.error ?
+                    <EllipsisText>{fieldState.error.message}</EllipsisText> :
+                    <Box>変更はダイアログを閉じるまで適用されません</Box>}
+              </Tooltip>
+            </FormHelperText>
+          </FormControl>
+        )}/>
+    </Stack>
+    <DialogActions>
+      {mode === 'edit' ? <Button onClick={onCancel}>
+        キャンセル
+      </Button> : <Button color='error' onClick={onResetData}>
+        データをリセット
+      </Button>}
+      <Button disabled={!formState.isValid}
+        onClick={handleSubmit((values) => {
+          const result = parseInput(values.data);
+          result.success && onSubmit?.(result.value);
+        })}>
+        適用
+      </Button>
+    </DialogActions>
+    <Snackbar open={isSnackbarOpen} key={snackbar?.key} message={snackbar?.msg}
+      anchorOrigin={{vertical: 'bottom', horizontal: 'right'}}
+      TransitionComponent={Slide}
+      autoHideDuration={2000} onClose={() => setSnackbarOpen(false)} />
+  </Dialog>;
+};
+
+const HiddenInput = styled('input')({
+  position: 'absolute',
+  width: 0,
+  height: 0,
+  appearance: 'none',
+  opacity: 0,
+});
+
+const EllipsisText = styled(Box)({
+  overflow: 'hidden',
+  textOverflow: 'ellipsis',
+});
+
+const PreText = styled(Box)({
+  whiteSpace: 'pre-wrap',
+  fontFamily: `'MyricaM M', Menlo, Monaco, 'Courier New', monospace`,
+});

--- a/components/settings/dataManagement/DataManagementDialog.tsx
+++ b/components/settings/dataManagement/DataManagementDialog.tsx
@@ -1,11 +1,11 @@
 import React, {
   ChangeEventHandler, DragEventHandler, MouseEventHandler, ReactNode,
-  useEffect, useId, useRef, useState,
+  forwardRef, useEffect, useId, useRef, useState,
 } from 'react';
 import {
   Box, Button, ButtonGroup, Dialog, DialogActions, DialogContent, DialogTitle,
   FormControl, FormHelperText, OutlinedInput, FormLabel,
-  Snackbar, Stack, Tooltip, styled, useTheme, useMediaQuery, Slide,
+  Snackbar, Stack, Tooltip, styled, useTheme, useMediaQuery, Slide, IconButton,
 } from '@mui/material';
 import {useTranslation} from 'next-i18next';
 import {Controller, useForm} from 'react-hook-form';
@@ -21,10 +21,17 @@ interface DataManagementFormValues {
 }
 
 // YYYY/MM/DD hh:mm:ss
-const formatter = new Intl.DateTimeFormat('ja-JP', {
+const formatter = new Intl.DateTimeFormat('ja-JP', { // sv-SE?
   year: 'numeric', month: '2-digit', day: '2-digit',
   hour: '2-digit', minute: '2-digit', second: '2-digit',
 });
+const createFileName = (base: string, ext: string, sep: string = '_') => {
+  const [date, time] = formatter.format(new Date())
+      .replaceAll('/', '')
+      .replaceAll(':', '')
+      .split(' ');
+  return `${[base, date, time].join(sep)}.${ext}`;
+};
 
 type Result<T, E = unknown> = {success: true, value: T} | {success: false, error: E}
 const catching = <T, >(block: () => T): Result<T> => {
@@ -33,6 +40,10 @@ const catching = <T, >(block: () => T): Result<T> => {
   } catch (e: unknown) {
     return {success: false, error: e};
   }
+};
+
+const idle = (opt?: Parameters<typeof requestIdleCallback>[1]) => {
+  return new Promise((resolve) => requestIdleCallback(resolve, opt));
 };
 
 interface MSTError extends Error {
@@ -63,8 +74,8 @@ export const DataManagementDialog = ({
   const {t} = useTranslation('home');
   const theme = useTheme();
   const isFullScreen = useMediaQuery(theme.breakpoints.down('md'));
-
   const store = useStore();
+
   const inputId = useId();
   const {
     getValues, setValue, reset, trigger,
@@ -82,10 +93,9 @@ export const DataManagementDialog = ({
     return () => clearTimeout(id);
   }, [trigger]);
 
-  type SnackbarContent = {
-    key: string,
-    msg: ReactNode,
-  };
+  const [isEditEnabled, setEditEnabled] = useState(mode === 'recovery');
+
+  type SnackbarContent = {key: string, msg: ReactNode};
   const [snackbar, setSnackbar] = useState<SnackbarContent | null>(null);
   const [isSnackbarOpen, setSnackbarOpen] = useState(false);
   const showSnackbar = (content: SnackbarContent) => {
@@ -93,37 +103,27 @@ export const DataManagementDialog = ({
     setSnackbarOpen(true);
   };
 
-  const handleCopy: MouseEventHandler = async (e) => {
+  const handleCopy: MouseEventHandler = async () => {
     await navigator.clipboard.writeText(getValues('data'));
     showSnackbar({key: 'copied', msg: 'Copied!'});
   };
 
-  const handlePaste: MouseEventHandler = async (e) => {
+  const handlePaste: MouseEventHandler = async () => {
     const value = await navigator.clipboard.readText();
     setValue('data', value, {shouldValidate: true});
     showSnackbar({key: 'pasted', msg: 'Pasted!'});
   };
 
-  const anchor = useRef<HTMLAnchorElement>(null);
-  const handleDownload: MouseEventHandler<HTMLButtonElement> = async (e) => {
-    if (!anchor.current) return;
+  const anchorRef = useRef<HTMLAnchorElement>(null);
+  const handleDownload: MouseEventHandler = async () => {
+    if (!anchorRef.current) return;
+    const a = anchorRef.current;
 
-    const blob = new Blob([
-      getValues('data'),
-    ], {
-      type: 'application/json',
-    });
-
-    const [date, time] = formatter.format(new Date())
-        .replaceAll('/', '')
-        .replaceAll(':', '')
-        .split(' ');
-    const name = `SenseiHelper_${date}_${time}.json`;
-
-    anchor.current.href = window.URL.createObjectURL(blob);
-    anchor.current.download = name;
-    anchor.current.click();
-    showSnackbar({key: 'exported', msg: `Exported to '${name}'`});
+    window.URL.revokeObjectURL(a.href);
+    a.href = window.URL.createObjectURL(new Blob([getValues('data')], {type: 'application/json'}));
+    a.download = createFileName('SenseiHelper', 'json');
+    a.click();
+    showSnackbar({key: 'exported', msg: `Exported to '${a.download}'`});
   };
 
   const handleUpload: ChangeEventHandler<HTMLInputElement> = async (e) => {
@@ -164,14 +164,16 @@ export const DataManagementDialog = ({
   return <Dialog open={open} fullWidth fullScreen={isFullScreen}
     PaperProps={{sx: {height: '100%'}}} onClose={onClose} onDrop={handleFileDrop}>
     <Stack component={DialogTitle} direction='row' alignItems='center' gap='0.5rem'>
-      データ管理
-      <Tooltip title='アプリのデータをバックアップしたり、破損したデータを手動で修復できます。'><InfoOutlined /></Tooltip>
+      {t('dataManagementDialog.title')}
+      <Tooltip title={t('dataManagementDialog.tips')}>
+        <IconButton><InfoOutlined /></IconButton>
+      </Tooltip>
     </Stack>
     <Stack component={DialogContent} direction='column'>
       <Stack flex='0 0 auto' direction='row' flexWrap='wrap' gap='1rem'>
         <ButtonGroup variant='contained' fullWidth sx={{flex: '1 1 max-content'}}>
-          <Button component='label' tabIndex={-1} startIcon={<FileDownload />}>
-            インポート
+          <Button component='label' tabIndex={-1} startIcon={<FileDownload />} role={undefined}>
+            {t('dataManagementDialog.importFile')}
             <HiddenInput type='file' accept='application/json' onChange={handleUpload} />
           </Button>
           <Button component='label' onClick={handlePaste} sx={{width: 'unset'}}>
@@ -180,8 +182,8 @@ export const DataManagementDialog = ({
         </ButtonGroup>
         <ButtonGroup variant='contained' fullWidth sx={{flex: '1 1 max-content'}}>
           <Button startIcon={<FileUpload />} onClick={handleDownload}>
-            エクスポート
-            <Box component='a' ref={anchor} display='none' />
+            {t('dataManagementDialog.exportFile')}
+            <Box component='a' ref={anchorRef} display='none' />
           </Button>
           <Button onClick={handleCopy} sx={{width: 'unset'}}>
             <ContentCopy fontSize='small'/>
@@ -190,22 +192,25 @@ export const DataManagementDialog = ({
       </Stack>
       <Controller control={control} name='data'
         rules={{
-          required: {value: true, message: '必須です'},
-          validate: (value) => {
+          required: {value: true, message: t('dataManagementDialog.helpText.required')},
+          validate: async (value) => {
+            await idle();
             const result = parseInput(value);
             return result.success || `${result.error}`;
           },
         }}
         render={({field, fieldState}) => (
-          <FormControl fullWidth variant='outlined' error={fieldState.invalid}
-            margin='normal' sx={{flex: '1 1 100%'}}>
+          <FormControl fullWidth variant='outlined' margin='normal' sx={{flex: '1 1 100%'}}
+            error={fieldState.invalid} disabled={!isEditEnabled}>
             <Stack direction='row' gap='0.5rem'>
-              <Box component={FormLabel} htmlFor={inputId} flex='1 1 auto'>JSON</Box>
-              <Box component={Button} variant='text' padding='0'
-                disabled={(!formState.isDirty)}
-                onClick={() => reset()}>
-                リセット
+              <Box component={FormLabel} htmlFor={inputId} flex='1 1 auto'>
+                {t('dataManagementDialog.formLabel')}
               </Box>
+              {!isEditEnabled ? <TextButton onClick={() => setEditEnabled(true)}>
+                {t('dataManagementDialog.enableEditing')}
+              </TextButton> : <TextButton disabled={!fieldState.isDirty} onClick={() => reset()}>
+                {t('dataManagementDialog.resetForm')}
+              </TextButton>}
             </Stack>
             <OutlinedInput id={inputId} notched={false}
               sx={{flex: '1', paddingInline: '1rem 0', paddingBlock: '0.1rem'}}
@@ -221,7 +226,7 @@ export const DataManagementDialog = ({
               <Tooltip title={fieldState.error && <PreText>{fieldState.error.message}</PreText>}>
                 {fieldState.error ?
                     <EllipsisText>{fieldState.error.message}</EllipsisText> :
-                    <Box>変更はダイアログを閉じるまで適用されません</Box>}
+                    <Box>{t('dataManagementDialog.helpText.default')}</Box>}
               </Tooltip>
             </FormHelperText>
           </FormControl>
@@ -229,16 +234,16 @@ export const DataManagementDialog = ({
     </Stack>
     <DialogActions>
       {mode === 'edit' ? <Button onClick={onCancel}>
-        キャンセル
+        {t('dataManagementDialog.cancel')}
       </Button> : <Button color='error' onClick={onResetData}>
-        データをリセット
+        {t('dataManagementDialog.resetData')}
       </Button>}
       <Button disabled={!formState.isValid}
         onClick={handleSubmit((values) => {
           const result = parseInput(values.data);
           result.success && onSubmit?.(result.value);
         })}>
-        適用
+        {t('dataManagementDialog.applyData')}
       </Button>
     </DialogActions>
     <Snackbar open={isSnackbarOpen} key={snackbar?.key} message={snackbar?.msg}
@@ -265,3 +270,10 @@ const PreText = styled(Box)({
   whiteSpace: 'pre-wrap',
   fontFamily: `'MyricaM M', Menlo, Monaco, 'Courier New', monospace`,
 });
+
+const TextButton = styled(forwardRef(function TextButton(props: any, ref: any) {
+  return <Button {...props} ref={ref} variant={props.variant ?? 'text'} />;
+}))({
+  paddingBlock: 0,
+  textTransform: 'none',
+}) as typeof Button;

--- a/components/settings/dataManagement/RestoreDataExceptionDialog.tsx
+++ b/components/settings/dataManagement/RestoreDataExceptionDialog.tsx
@@ -6,12 +6,13 @@ import BuiLinedText from 'components/bui/text/BuiLinedText';
 import Box from '@mui/material/Box';
 import {useTranslation} from 'next-i18next';
 
-const RestoreDataExceptionDialog = (
-    {isOpened = false, corruptedData,
-      handleDataReset}: {isOpened: boolean,
-      corruptedData: string
-      handleDataReset : () => void}
-) => {
+const RestoreDataExceptionDialog = ({
+  isOpened = false, corruptedData,
+  handleDataReset, handleManageData,
+}: {
+  isOpened?: boolean, corruptedData: string
+  handleDataReset: () => void, handleManageData: () => void,
+}) => {
   const {t} = useTranslation('home');
 
   return <BuiDialog open={isOpened} >
@@ -43,6 +44,9 @@ const RestoreDataExceptionDialog = (
       <Box sx={{flex: '1 0 0 '}}/>
       <Button variant="contained" color={'error'} onClick={handleDataReset}>
         {t('notifyDataCorruptionDialog.clearDataButton')}
+      </Button>
+      <Button variant="contained" color={'info'} onClick={handleManageData}>
+        {t('notifyDataCorruptionDialog.openDataManagement')}
       </Button>
       <Box sx={{flex: '1 0 0 '}}/>
     </DialogActions>

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -15,14 +15,20 @@ import wizDefaultTheme from 'components/bui/theme';
 import WizAppBar from 'components/appBar/WizAppBar';
 import React, {useEffect, useState} from 'react';
 import {applySnapshot, onSnapshot} from 'mobx-state-tree';
-import {getFromLocalStorage, removeFromLocalStorage, setToLocalStorage} from 'common/LocalStorageUtil';
-import RestoreDataExceptionDialog from 'components/settings/dataManagement/RestoreDataExceptionDialog';
+import {
+  getFromLocalStorage, removeFromLocalStorage, setToLocalStorage,
+} from 'common/LocalStorageUtil';
+import RestoreDataExceptionDialog
+  from 'components/settings/dataManagement/RestoreDataExceptionDialog';
 import {initializeAnalytics} from 'common/gtag';
+import {DataManagementDialog} from 'components/settings/dataManagement/DataManagementDialog';
 
 
+// eslint-disable-next-line require-jsdoc
 function MyApp({Component, pageProps}: AppProps) {
   const [isStoreInitialized, setIsStoreInitialized] = useState(false);
   const [isExceptionDialogOpened, setIsExceptionDialogOpened] = useState(false);
+  const [isDataMangementDialogOpened, setDataManagementDialogOpened] = useState(false);
   const [corruptedData, setCorruptedData] = useState('');
 
   const store = initializeWizStore(pageProps.initialState);
@@ -35,24 +41,13 @@ function MyApp({Component, pageProps}: AppProps) {
         json = JSON.parse(persistedSnapshot);
         applySnapshot(store, json);
       } catch (e) {
-        const hasEnteredPlentyInventoryData = Object.values(json?.equipmentsRequirementStore?.piecesInventory ?? {}).length >= 10;
-        const hasEnteredPlentyEquipmentData = json?.equipmentsRequirementStore?.requirementByEquipments?.length >= 5;
-        const hasEnteredPlentyPiecesData = json?.equipmentsRequirementStore?.requirementByPieces?.length >= 10;
+        setIsExceptionDialogOpened(true);
+        setDataManagementDialogOpened(true);
 
-        // Notify reset to back up corrupted data if they have entered a lot.
-        if (hasEnteredPlentyInventoryData || hasEnteredPlentyEquipmentData || hasEnteredPlentyPiecesData) {
-          setIsExceptionDialogOpened(true);
-        } else {
-          handleDataReset();
-        }
-
-        const exceptionStorage = {
+        setToLocalStorage(wizExceptionStorageLocalStorageKey, JSON.stringify({
           exception: String(e),
           [wizStorageLocalStorageKey]: json ?? persistedSnapshot,
-        };
-        setToLocalStorage(wizExceptionStorageLocalStorageKey,
-            JSON.stringify(exceptionStorage)
-        );
+        }));
 
         setCorruptedData(persistedSnapshot);
       }
@@ -77,12 +72,20 @@ function MyApp({Component, pageProps}: AppProps) {
     <StoreContext.Provider value={store}>
       <ThemeProvider theme={wizDefaultTheme}>
         <>
-          {
-            isExceptionDialogOpened? <RestoreDataExceptionDialog isOpened={isExceptionDialogOpened}
-              corruptedData={corruptedData}
-              handleDataReset={handleDataReset} /> :
-                null
-          }
+          {isExceptionDialogOpened && <RestoreDataExceptionDialog isOpened={isExceptionDialogOpened}
+            corruptedData={corruptedData}
+            handleDataReset={handleDataReset} />}
+          {isDataMangementDialogOpened && <DataManagementDialog key={corruptedData}
+            open={isDataMangementDialogOpened} mode='recovery'
+            value={corruptedData}
+            onResetData={() => {
+              handleDataReset();
+              setDataManagementDialogOpened(false);
+            }}
+            onSubmit={(snapshot) => {
+              applySnapshot(store, snapshot);
+              setDataManagementDialogOpened(false);
+            }} />}
         </>
 
         <CssBaseline />

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -41,15 +41,13 @@ function MyApp({Component, pageProps}: AppProps) {
         json = JSON.parse(persistedSnapshot);
         applySnapshot(store, json);
       } catch (e) {
+        setCorruptedData(persistedSnapshot);
         setIsExceptionDialogOpened(true);
-        setDataManagementDialogOpened(true);
 
         setToLocalStorage(wizExceptionStorageLocalStorageKey, JSON.stringify({
           exception: String(e),
           [wizStorageLocalStorageKey]: json ?? persistedSnapshot,
         }));
-
-        setCorruptedData(persistedSnapshot);
       }
     }
     setIsStoreInitialized(true);
@@ -67,6 +65,10 @@ function MyApp({Component, pageProps}: AppProps) {
     setIsExceptionDialogOpened(false);
     removeFromLocalStorage(wizStorageLocalStorageKey);
   };
+  const handleManageData = () => {
+    setIsExceptionDialogOpened(false);
+    setDataManagementDialogOpened(true);
+  };
 
   return (
     <StoreContext.Provider value={store}>
@@ -74,7 +76,8 @@ function MyApp({Component, pageProps}: AppProps) {
         <>
           {isExceptionDialogOpened && <RestoreDataExceptionDialog isOpened={isExceptionDialogOpened}
             corruptedData={corruptedData}
-            handleDataReset={handleDataReset} />}
+            handleDataReset={handleDataReset}
+            handleManageData={handleManageData} />}
           {isDataMangementDialogOpened && <DataManagementDialog key={corruptedData}
             open={isDataMangementDialogOpened} mode='recovery'
             value={corruptedData}

--- a/public/locales/en/home.json
+++ b/public/locales/en/home.json
@@ -71,6 +71,7 @@
   "otherStagesSkippedReason": "Skipped because of inefficiency",
   "privacy": "Privacy",
   "settings": "Settings",
+  "dataManagement": "Manage Data",
   "about": "About",
   "SenseiHelper": "Sensei Helper",
   "settingsDialogTitle": "Settings",
@@ -83,7 +84,24 @@
     "explanation": "It seems like your data is corrupted, your settings and equipment data will be reset.",
     "backupAndContactUs": "Below is your corrupted data, if the error persists, you can take a backup and contact the developer.",
     "clearDataButton": "Clear Data",
+    "openDataManagement": "Manage Data",
     "noData": "No Data"
+  },
+  "dataManagementDialog": {
+    "title": "Manage Data",
+    "tips": "You can backup app data or manually repair corrupted data.",
+    "importFile": "Import",
+    "exportFile": "Export",
+    "formLabel": "JSON",
+    "enableEditing": "Enable Editing",
+    "resetForm": "Reset", 
+    "helpText": {
+      "default": "Changes are not applied until the dialog is closed",
+      "required": "Input JSON"
+    },
+    "cancel": "Cancel",
+    "resetData": "Clear Data",
+    "applyData": "Apply"
   },
   "error404": "This page could not be found.",
   "error500": "Internal Server Error.",

--- a/public/locales/ja/home.json
+++ b/public/locales/ja/home.json
@@ -70,6 +70,7 @@
   "otherStagesSkippedReason": "非効率のためスキップしました",
   "privacy": "プライバシー",
   "settings": "設定",
+  "dataManagement": "データ管理",
   "about": "本ツールについて",
   "SenseiHelper": "先生ヘルパー",
   "settingsDialogTitle": "設定",
@@ -82,7 +83,24 @@
     "explanation": "データが破損してるため、装備データと設定のリセットは必要です。",
     "backupAndContactUs": "引き続き問題が発生する場合は、エクスポートしたデータをバックアップして、開発者に連絡してください。",
     "clearDataButton": "データリセット",
+    "openDataManagement": "データ管理を開く",
     "noData": "データがありません"
+  },
+  "dataManagementDialog": {
+    "title": "データ管理",
+    "tips": "アプリのデータをバックアップしたり、破損したデータを手動で修復できます。",
+    "importFile": "インポート",
+    "exportFile": "エクスポート",
+    "formLabel": "JSON",
+    "enableEditing": "編集を有効にする",
+    "resetForm": "リセット", 
+    "helpText": {
+      "default": "変更はダイアログを閉じるまで適用されません",
+      "required": "JSONを入力してください"
+    },
+    "cancel": "キャンセル",
+    "resetData": "データをリセット",
+    "applyData": "適用"
   },
   "error404": "お探しのページは見つかりませんでした。",
   "error500": "サーバー内部エラー",

--- a/public/locales/zh/home.json
+++ b/public/locales/zh/home.json
@@ -70,6 +70,7 @@
   "otherStagesSkippedReason": "因刷图效率不高而跳过",
   "privacy": "隐私",
   "settings": "设置",
+  "dataManagement": "数据管理",
   "about": "关于",
   "SenseiHelper": "Sensei Helper",
   "settingsDialogTitle": "设置",
@@ -82,7 +83,24 @@
     "explanation": "你的数据似乎已经损坏，设置和装备数据需要被清空。",
     "backupAndContactUs": "下面是导出的当前应用数据，如果问题持续出现，可以自行备份并联系开发者。",
     "clearDataButton": "清空数据",
+    "openDataManagement": "数据管理",
     "noData": "无数据"
+  },
+  "dataManagementDialog": {
+    "title": "数据管理",
+    "tips": "您可以备份应用程序数据，也可以手动修复损坏的数据。",
+    "importFile": "导入",
+    "exportFile": "导出",
+    "formLabel": "JSON",
+    "enableEditing": "启用编辑",
+    "resetForm": "重置",
+    "helpText": {
+      "default": "更改将在关闭对话框后生效",
+      "required": "请输入JSON"
+    },
+    "cancel": "取消",
+    "resetData": "重置数据",
+    "applyData": "应用"
   },
   "error404": "此页面无法找到",
   "error500": "服务器内部错误",

--- a/stores/EquipmentsRequirementStore.ts
+++ b/stores/EquipmentsRequirementStore.ts
@@ -1,33 +1,26 @@
 import {Instance, SnapshotIn, SnapshotOut, types} from 'mobx-state-tree';
-import {InventoryForm} from 'components/calculationInput/equipments/inventory/InventoryUpdateDialog';
-
-let equipmentsRequirementStore: IEquipmentsRequirementStore | undefined;
+import {InventoryForm}
+  from 'components/calculationInput/equipments/inventory/InventoryUpdateDialog';
 
 const byPiece = types
-    .model(
-        {
-          pieceId: types.string,
-          count: types.number,
-        }
-    );
+    .model('RequirementByPiece', {
+      pieceId: types.string,
+      count: types.number,
+    });
 
 const byEquipment = types
-    .model(
-        {
-          currentEquipmentId: types.string,
-          targetEquipmentId: types.string,
-          count: types.number,
-          nickname: types.optional(types.string, ''),
-        }
-    );
+    .model('RequirementByEquipment', {
+      currentEquipmentId: types.string,
+      targetEquipmentId: types.string,
+      count: types.number,
+      nickname: types.optional(types.string, ''),
+    });
 
 const pieceInventory = types
-    .model(
-        {
-          pieceId: types.identifier,
-          inStockCount: types.number,
-        }
-    );
+    .model('PieceInventory', {
+      pieceId: types.identifier,
+      inStockCount: types.number,
+    });
 
 export enum RequirementMode {
   ByPiece = 'ByPiece',
@@ -40,12 +33,18 @@ export enum ResultMode {
 }
 
 export const EquipmentsRequirementStore = types
-    .model({
+    .model('EquipmentsRequirementStore', {
       requirementByPieces: types.array(byPiece),
       requirementByEquipments: types.array(byEquipment),
       piecesInventory: types.map(pieceInventory),
-      requirementMode: types.optional(types.enumeration<RequirementMode>('RequirementMode', Object.values(RequirementMode)), RequirementMode.ByEquipment),
-      resultMode: types.optional(types.enumeration<ResultMode>('ResultMode', Object.values(ResultMode)), ResultMode.LinearProgram),
+      requirementMode: types.optional(
+          types.enumeration<RequirementMode>('RequirementMode', Object.values(RequirementMode)),
+          RequirementMode.ByEquipment
+      ),
+      resultMode: types.optional(
+          types.enumeration<ResultMode>('ResultMode', Object.values(ResultMode)),
+          ResultMode.LinearProgram
+      ),
     })
     .actions((self) => {
       const addPiecesRequirement = (requirement : IRequirementByPiece) => {

--- a/stores/GameInfoStore.ts
+++ b/stores/GameInfoStore.ts
@@ -3,7 +3,7 @@ import {GameServer} from 'model/Equipment';
 
 
 export const GameInfoStore = types
-    .model({
+    .model('GameInfoStore', {
       // A number that decides whether game is under drop campaign
       // if so, what is the campaign ratio
       normalMissionItemDropRatio: 1,

--- a/stores/StageCalculationStateStore.ts
+++ b/stores/StageCalculationStateStore.ts
@@ -3,7 +3,7 @@ import {RequirementMode} from 'stores/EquipmentsRequirementStore';
 
 
 export const StageCalculationStateStore = types
-    .model({
+    .model('StageCalculationStateStore', {
       requirementInefficacy: types.model({
         isByPiecesInefficient: false,
         isByEquipmentsInefficient: false,

--- a/stores/WizSettingsStore.ts
+++ b/stores/WizSettingsStore.ts
@@ -1,7 +1,7 @@
 import {Instance, types} from 'mobx-state-tree';
 
 export const WizSettingsStore = types
-    .model({
+    .model('WizSettingsStore', {
       appLanguage: types.enumeration('WizLanguage', ['en', 'cn', 'jp']),
     });
 

--- a/stores/WizStore.ts
+++ b/stores/WizStore.ts
@@ -1,6 +1,8 @@
 import {createContext, useContext} from 'react';
 import {applySnapshot, Instance, SnapshotIn, SnapshotOut, types} from 'mobx-state-tree';
-import {EquipmentsRequirementStore, RequirementMode, ResultMode} from 'stores/EquipmentsRequirementStore';
+import {
+  EquipmentsRequirementStore, RequirementMode, ResultMode,
+} from 'stores/EquipmentsRequirementStore';
 import {enableStaticRendering} from 'mobx-react-lite';
 import {GameInfoStore} from 'stores/GameInfoStore';
 import {GameServer} from 'model/Equipment';
@@ -11,7 +13,7 @@ enableStaticRendering(typeof window === 'undefined');
 let wizStore: IWizStore | undefined;
 
 const WizStore = types
-    .model({
+    .model('WizStore', {
       equipmentsRequirementStore: types.optional(EquipmentsRequirementStore, {
         requirementByPieces: [],
         requirementByEquipments: [],
@@ -46,6 +48,7 @@ export const isWizStore = (input: any) => WizStore.is(input);
 export const wizStorageLocalStorageKey = 'SenseiHelperStore';
 export const wizExceptionStorageLocalStorageKey = 'SenseiHelperStoreException';
 
+// eslint-disable-next-line require-jsdoc
 export function initializeWizStore(snapshot = null) {
   const _store = wizStore ?? WizStore.create({
     equipmentsRequirementStore: {
@@ -80,6 +83,7 @@ export function initializeWizStore(snapshot = null) {
 
 export const StoreContext = createContext(initializeWizStore());
 
+// eslint-disable-next-line require-jsdoc
 export function useStore() {
   const context = useContext(StoreContext);
   if (context === undefined) {


### PR DESCRIPTION
Added data management dialog for exporting, importing, and editing app data.
It is intended to be used for data backup.
I also added a button to open this dialog instead of resetting when the data is corrupted.